### PR TITLE
Add “Nimble OS by SNMP” template for storage device monitoring

### DIFF
--- a/Storage_Devices/Nimble_OS_template.yaml
+++ b/Storage_Devices/Nimble_OS_template.yaml
@@ -80,7 +80,7 @@ zabbix_export:
             - type: MULTIPLIER
               parameters:
                 - '0.001'
-            - type: SIMPLE_CHANGE
+            - type: CHANGE_PER_SECOND
           tags:
             - tag: Application
               value: 'Nimble OS'
@@ -97,7 +97,7 @@ zabbix_export:
             - type: MULTIPLIER
               parameters:
                 - '0.001'
-            - type: SIMPLE_CHANGE
+            - type: CHANGE_PER_SECOND
           tags:
             - tag: Application
               value: 'Nimble OS'
@@ -215,7 +215,7 @@ zabbix_export:
           trends: '0'
           description: 'Cache-hit count for non-sequential reads since last poll.'
           preprocessing:
-            - type: SIMPLE_CHANGE
+            - type: CHANGE_PER_SECOND
           master_item:
             key: .1.3.6.1.4.1.37447.1.3.16.0
           tags:
@@ -228,7 +228,7 @@ zabbix_export:
           trends: '0'
           description: 'Read I/O operations completed since previous check.'
           preprocessing:
-            - type: SIMPLE_CHANGE
+            - type: CHANGE_PER_SECOND
           master_item:
             key: .1.3.6.1.4.1.37447.1.3.2.0
           tags:
@@ -241,7 +241,7 @@ zabbix_export:
           trends: '0'
           description: 'Number of Read I/O bytes (sequential and random).'
           preprocessing:
-            - type: SIMPLE_CHANGE
+            - type: CHANGE_PER_SECOND
           master_item:
             key: .1.3.6.1.4.1.37447.1.3.8.0
           tags:
@@ -258,7 +258,7 @@ zabbix_export:
             - type: MULTIPLIER
               parameters:
                 - '0.001'
-            - type: SIMPLE_CHANGE
+            - type: CHANGE_PER_SECOND
           master_item:
             key: .1.3.6.1.4.1.37447.1.3.6.0
           tags:
@@ -271,7 +271,7 @@ zabbix_export:
           trends: '0'
           description: 'Sequential read operations completed since last poll.'
           preprocessing:
-            - type: SIMPLE_CHANGE
+            - type: CHANGE_PER_SECOND
           master_item:
             key: .1.3.6.1.4.1.37447.1.3.3.0
           tags:
@@ -285,7 +285,7 @@ zabbix_export:
           units: B
           description: 'Bytes read by sequential reads during the last polling interval.'
           preprocessing:
-            - type: SIMPLE_CHANGE
+            - type: CHANGE_PER_SECOND
           master_item:
             key: .1.3.6.1.4.1.37447.1.3.9.0
           tags:
@@ -298,7 +298,7 @@ zabbix_export:
           trends: '0'
           description: 'Sequential write operations completed since last check.'
           preprocessing:
-            - type: SIMPLE_CHANGE
+            - type: CHANGE_PER_SECOND
           master_item:
             key: .1.3.6.1.4.1.37447.1.3.5.0
           tags:
@@ -311,7 +311,7 @@ zabbix_export:
           trends: '0'
           description: 'Bytes written by sequential writes during the last polling interval.'
           preprocessing:
-            - type: SIMPLE_CHANGE
+            - type: CHANGE_PER_SECOND
           master_item:
             key: .1.3.6.1.4.1.37447.1.3.11.0
           tags:
@@ -324,7 +324,7 @@ zabbix_export:
           trends: '0'
           description: 'Number of write I/O operations completed since the previous check.'
           preprocessing:
-            - type: SIMPLE_CHANGE
+            - type: CHANGE_PER_SECOND
           master_item:
             key: .1.3.6.1.4.1.37447.1.3.4.0
           tags:
@@ -338,7 +338,7 @@ zabbix_export:
           units: B
           description: 'Bytes written to disk during the last polling interval.'
           preprocessing:
-            - type: SIMPLE_CHANGE
+            - type: CHANGE_PER_SECOND
           master_item:
             key: .1.3.6.1.4.1.37447.1.3.10.0
           tags:
@@ -355,7 +355,7 @@ zabbix_export:
             - type: MULTIPLIER
               parameters:
                 - '0.001'
-            - type: SIMPLE_CHANGE
+            - type: CHANGE_PER_SECOND
           master_item:
             key: .1.3.6.1.4.1.37447.1.3.7.0
           tags:
@@ -525,7 +525,7 @@ zabbix_export:
                 - type: MULTIPLIER
                   parameters:
                     - '0.001'
-                - type: SIMPLE_CHANGE
+                - type: CHANGE_PER_SECOND
               tags:
                 - tag: Application
                   value: 'Nimble OS'
@@ -992,7 +992,7 @@ zabbix_export:
               trends: '0'
               description: 'Per-interval increase in Non-sequential Read I/O hits to Memory.'
               preprocessing:
-                - type: SIMPLE_CHANGE
+                - type: CHANGE_PER_SECOND
               master_item:
                 key: '.1.3.6.1.4.1.37447.1.2.1.19.[{#SNMPINDEX}]'
               tags:
@@ -1005,7 +1005,7 @@ zabbix_export:
               trends: '0'
               description: 'Per-interval increase in non-sequential Read I/O hits to SSD.'
               preprocessing:
-                - type: SIMPLE_CHANGE
+                - type: CHANGE_PER_SECOND
               master_item:
                 key: '.1.3.6.1.4.1.37447.1.2.1.20.[{#SNMPINDEX}]'
               tags:
@@ -1018,7 +1018,7 @@ zabbix_export:
               trends: '0'
               description: 'Per-interval increase in non-sequential Read I/O hits (to Memory and SSD).'
               preprocessing:
-                - type: SIMPLE_CHANGE
+                - type: CHANGE_PER_SECOND
               master_item:
                 key: '.1.3.6.1.4.1.37447.1.2.1.18.[{#SNMPINDEX}]'
               tags:
@@ -1032,7 +1032,7 @@ zabbix_export:
               units: B
               description: 'Per-interval increase in Read I/O bytes (sequential and random).'
               preprocessing:
-                - type: SIMPLE_CHANGE
+                - type: CHANGE_PER_SECOND
               master_item:
                 key: '.1.3.6.1.4.1.37447.1.2.1.15.[{#SNMPINDEX}]'
               tags:
@@ -1045,7 +1045,7 @@ zabbix_export:
               trends: '0'
               description: 'Per-interval increase in the number of Read I/O operations with latency between 0 and 100 microseconds.'
               preprocessing:
-                - type: SIMPLE_CHANGE
+                - type: CHANGE_PER_SECOND
               master_item:
                 key: '.1.3.6.1.4.1.37447.1.2.1.21.[{#SNMPINDEX}]'
               tags:
@@ -1058,7 +1058,7 @@ zabbix_export:
               trends: '0'
               description: 'Per-interval increase in the number of Read I/O operations with latency between 1 and 2 milliseconds.'
               preprocessing:
-                - type: SIMPLE_CHANGE
+                - type: CHANGE_PER_SECOND
               master_item:
                 key: '.1.3.6.1.4.1.37447.1.2.1.25.[{#SNMPINDEX}]'
               tags:
@@ -1071,7 +1071,7 @@ zabbix_export:
               trends: '0'
               description: 'Per-interval increase in the number of Read I/O operations with latency between 2 and 5 milliseconds.'
               preprocessing:
-                - type: SIMPLE_CHANGE
+                - type: CHANGE_PER_SECOND
               master_item:
                 key: '.1.3.6.1.4.1.37447.1.2.1.26.[{#SNMPINDEX}]'
               tags:
@@ -1084,7 +1084,7 @@ zabbix_export:
               trends: '0'
               description: 'Per-interval increase in the number of Read I/O operations with latency between 5 and 10 milliseconds.'
               preprocessing:
-                - type: SIMPLE_CHANGE
+                - type: CHANGE_PER_SECOND
               master_item:
                 key: '.1.3.6.1.4.1.37447.1.2.1.27.[{#SNMPINDEX}]'
               tags:
@@ -1097,7 +1097,7 @@ zabbix_export:
               trends: '0'
               description: 'Per-interval increase in the number of Read I/O operations with latency between 10 and 20 milliseconds.'
               preprocessing:
-                - type: SIMPLE_CHANGE
+                - type: CHANGE_PER_SECOND
               master_item:
                 key: '.1.3.6.1.4.1.37447.1.2.1.28.[{#SNMPINDEX}]'
               tags:
@@ -1110,7 +1110,7 @@ zabbix_export:
               trends: '0'
               description: 'Per-interval increase in the number of Read I/O operations with latency between 20 and 50 milliseconds.'
               preprocessing:
-                - type: SIMPLE_CHANGE
+                - type: CHANGE_PER_SECOND
               master_item:
                 key: '.1.3.6.1.4.1.37447.1.2.1.29.[{#SNMPINDEX}]'
               tags:
@@ -1123,7 +1123,7 @@ zabbix_export:
               trends: '0'
               description: 'Per-interval increase in the number of Read I/O operations with latency between 50 and 100 milliseconds.'
               preprocessing:
-                - type: SIMPLE_CHANGE
+                - type: CHANGE_PER_SECOND
               master_item:
                 key: '.1.3.6.1.4.1.37447.1.2.1.30.[{#SNMPINDEX}]'
               tags:
@@ -1136,7 +1136,7 @@ zabbix_export:
               trends: '0'
               description: 'Per-interval increase in the number of Read I/O operations with latency between 100 and 200 milliseconds.'
               preprocessing:
-                - type: SIMPLE_CHANGE
+                - type: CHANGE_PER_SECOND
               master_item:
                 key: '.1.3.6.1.4.1.37447.1.2.1.31.[{#SNMPINDEX}]'
               tags:
@@ -1149,7 +1149,7 @@ zabbix_export:
               trends: '0'
               description: 'Per-interval increase in the number of Read I/O operations with latency between 100 and 200 microseconds.'
               preprocessing:
-                - type: SIMPLE_CHANGE
+                - type: CHANGE_PER_SECOND
               master_item:
                 key: '.1.3.6.1.4.1.37447.1.2.1.22.[{#SNMPINDEX}]'
               tags:
@@ -1162,7 +1162,7 @@ zabbix_export:
               trends: '0'
               description: 'Per-interval increase in the number of Read I/O operations with latency between 200 and 500 milliseconds.'
               preprocessing:
-                - type: SIMPLE_CHANGE
+                - type: CHANGE_PER_SECOND
               master_item:
                 key: '.1.3.6.1.4.1.37447.1.2.1.32.[{#SNMPINDEX}]'
               tags:
@@ -1174,7 +1174,7 @@ zabbix_export:
               key: 'volIoReadLatency200uTo500u.Delta[{#SNMPINDEX}]'
               trends: '0'
               preprocessing:
-                - type: SIMPLE_CHANGE
+                - type: CHANGE_PER_SECOND
               master_item:
                 key: '.1.3.6.1.4.1.37447.1.2.1.23.[{#SNMPINDEX}]'
               tags:
@@ -1187,7 +1187,7 @@ zabbix_export:
               trends: '0'
               description: 'Per-interval increase in the number of Read I/O operations with latency above 500 milliseconds.'
               preprocessing:
-                - type: SIMPLE_CHANGE
+                - type: CHANGE_PER_SECOND
               master_item:
                 key: '.1.3.6.1.4.1.37447.1.2.1.33.[{#SNMPINDEX}]'
               tags:
@@ -1200,7 +1200,7 @@ zabbix_export:
               trends: '0'
               description: 'Per-interval increase in the number of Read I/O operations with latency between 1/2 and 1 milliseconds.'
               preprocessing:
-                - type: SIMPLE_CHANGE
+                - type: CHANGE_PER_SECOND
               master_item:
                 key: '.1.3.6.1.4.1.37447.1.2.1.24.[{#SNMPINDEX}]'
               tags:
@@ -1213,7 +1213,7 @@ zabbix_export:
               trends: '0'
               description: 'Per-interval increase in the number of Read I/Os (sequential and random).'
               preprocessing:
-                - type: SIMPLE_CHANGE
+                - type: CHANGE_PER_SECOND
               master_item:
                 key: '.1.3.6.1.4.1.37447.1.2.1.13.[{#SNMPINDEX}]'
               tags:
@@ -1230,7 +1230,7 @@ zabbix_export:
                 - type: MULTIPLIER
                   parameters:
                     - '0.001'
-                - type: SIMPLE_CHANGE
+                - type: CHANGE_PER_SECOND
               master_item:
                 key: '.1.3.6.1.4.1.37447.1.2.1.14.[{#SNMPINDEX}]'
               tags:
@@ -1244,7 +1244,7 @@ zabbix_export:
               units: B
               description: 'Per-interval increase in the number of Sequential Read I/O bytes.'
               preprocessing:
-                - type: SIMPLE_CHANGE
+                - type: CHANGE_PER_SECOND
               master_item:
                 key: '.1.3.6.1.4.1.37447.1.2.1.17.[{#SNMPINDEX}]'
               tags:
@@ -1257,7 +1257,7 @@ zabbix_export:
               trends: '0'
               description: 'Per-interval increase in the number of Sequential Read I/O operations.'
               preprocessing:
-                - type: SIMPLE_CHANGE
+                - type: CHANGE_PER_SECOND
               master_item:
                 key: '.1.3.6.1.4.1.37447.1.2.1.16.[{#SNMPINDEX}]'
               tags:
@@ -1271,7 +1271,7 @@ zabbix_export:
               units: B
               description: 'Per-interval increase in the number of Sequential Write I/O bytes.'
               preprocessing:
-                - type: SIMPLE_CHANGE
+                - type: CHANGE_PER_SECOND
               master_item:
                 key: '.1.3.6.1.4.1.37447.1.2.1.38.[{#SNMPINDEX}]'
               tags:
@@ -1284,7 +1284,7 @@ zabbix_export:
               trends: '0'
               description: 'Per-interval increase in the number of Sequential Write I/O operations.'
               preprocessing:
-                - type: SIMPLE_CHANGE
+                - type: CHANGE_PER_SECOND
               master_item:
                 key: '.1.3.6.1.4.1.37447.1.2.1.37.[{#SNMPINDEX}]'
               tags:
@@ -1298,7 +1298,7 @@ zabbix_export:
               units: B
               description: 'Per-interval increase in the number of Write I/O bytes (sequential and random).'
               preprocessing:
-                - type: SIMPLE_CHANGE
+                - type: CHANGE_PER_SECOND
               master_item:
                 key: '.1.3.6.1.4.1.37447.1.2.1.36.[{#SNMPINDEX}]'
               tags:
@@ -1311,7 +1311,7 @@ zabbix_export:
               trends: '0'
               description: 'Per-interval increase in the number of Write I/O operations with latency between 0 and 100 microseconds.'
               preprocessing:
-                - type: SIMPLE_CHANGE
+                - type: CHANGE_PER_SECOND
               master_item:
                 key: '.1.3.6.1.4.1.37447.1.2.1.39.[{#SNMPINDEX}]'
               tags:
@@ -1324,7 +1324,7 @@ zabbix_export:
               trends: '0'
               description: 'Per-interval increase in the number of Write I/O operations with latency between 1 and 2 milliseconds.'
               preprocessing:
-                - type: SIMPLE_CHANGE
+                - type: CHANGE_PER_SECOND
               master_item:
                 key: '.1.3.6.1.4.1.37447.1.2.1.43.[{#SNMPINDEX}]'
               tags:
@@ -1337,7 +1337,7 @@ zabbix_export:
               trends: '0'
               description: 'Per-interval increase in the number of Write I/O operations with latency between 2 and 5 milliseconds.'
               preprocessing:
-                - type: SIMPLE_CHANGE
+                - type: CHANGE_PER_SECOND
               master_item:
                 key: '.1.3.6.1.4.1.37447.1.2.1.44.[{#SNMPINDEX}]'
               tags:
@@ -1350,7 +1350,7 @@ zabbix_export:
               trends: '0'
               description: 'Per-interval increase in the number of Write I/O operations with latency between 5 and 10 milliseconds.'
               preprocessing:
-                - type: SIMPLE_CHANGE
+                - type: CHANGE_PER_SECOND
               master_item:
                 key: '.1.3.6.1.4.1.37447.1.2.1.45.[{#SNMPINDEX}]'
               tags:
@@ -1363,7 +1363,7 @@ zabbix_export:
               trends: '0'
               description: 'Per-interval increase in the number of Write I/O operations with latency between 10 and 20 milliseconds.'
               preprocessing:
-                - type: SIMPLE_CHANGE
+                - type: CHANGE_PER_SECOND
               master_item:
                 key: '.1.3.6.1.4.1.37447.1.2.1.46.[{#SNMPINDEX}]'
               tags:
@@ -1376,7 +1376,7 @@ zabbix_export:
               trends: '0'
               description: 'Per-interval increase in the number of Write I/O operations with latency between 20 and 50 milliseconds.'
               preprocessing:
-                - type: SIMPLE_CHANGE
+                - type: CHANGE_PER_SECOND
               master_item:
                 key: '.1.3.6.1.4.1.37447.1.2.1.47.[{#SNMPINDEX}]'
               tags:
@@ -1389,7 +1389,7 @@ zabbix_export:
               trends: '0'
               description: 'Per-interval increase in the number of Write I/O operations with latency between 50 and 100 milliseconds.'
               preprocessing:
-                - type: SIMPLE_CHANGE
+                - type: CHANGE_PER_SECOND
               master_item:
                 key: '.1.3.6.1.4.1.37447.1.2.1.48.[{#SNMPINDEX}]'
               tags:
@@ -1402,7 +1402,7 @@ zabbix_export:
               trends: '0'
               description: 'Per-interval increase in the number of Write I/O operations with latency between 100 and 200 milliseconds.'
               preprocessing:
-                - type: SIMPLE_CHANGE
+                - type: CHANGE_PER_SECOND
               master_item:
                 key: '.1.3.6.1.4.1.37447.1.2.1.49.[{#SNMPINDEX}]'
               tags:
@@ -1415,7 +1415,7 @@ zabbix_export:
               trends: '0'
               description: 'Per-interval increase in the number of Write I/O operations with latency between 100 and 200 microseconds.'
               preprocessing:
-                - type: SIMPLE_CHANGE
+                - type: CHANGE_PER_SECOND
               master_item:
                 key: '.1.3.6.1.4.1.37447.1.2.1.40.[{#SNMPINDEX}]'
               tags:
@@ -1428,7 +1428,7 @@ zabbix_export:
               trends: '0'
               description: 'Per-interval increase in the number of Write I/O operations with latency between 200 and 500 milliseconds.'
               preprocessing:
-                - type: SIMPLE_CHANGE
+                - type: CHANGE_PER_SECOND
               master_item:
                 key: '.1.3.6.1.4.1.37447.1.2.1.50.[{#SNMPINDEX}]'
               tags:
@@ -1441,7 +1441,7 @@ zabbix_export:
               trends: '0'
               description: 'Per-interval increase in the number of Write I/O operations with latency between 200 and 500 microseconds.'
               preprocessing:
-                - type: SIMPLE_CHANGE
+                - type: CHANGE_PER_SECOND
               master_item:
                 key: '.1.3.6.1.4.1.37447.1.2.1.41.[{#SNMPINDEX}]'
               tags:
@@ -1454,7 +1454,7 @@ zabbix_export:
               trends: '0'
               description: 'Per-interval increase in the number of Write I/O operations with latency above 500 milliseconds.'
               preprocessing:
-                - type: SIMPLE_CHANGE
+                - type: CHANGE_PER_SECOND
               master_item:
                 key: '.1.3.6.1.4.1.37447.1.2.1.51.[{#SNMPINDEX}]'
               tags:
@@ -1467,7 +1467,7 @@ zabbix_export:
               trends: '0'
               description: 'Per-interval increase in the number of Write I/O operations with latency between 1/2 and 1 milliseconds.'
               preprocessing:
-                - type: SIMPLE_CHANGE
+                - type: CHANGE_PER_SECOND
               master_item:
                 key: '.1.3.6.1.4.1.37447.1.2.1.42.[{#SNMPINDEX}]'
               tags:
@@ -1480,7 +1480,7 @@ zabbix_export:
               trends: '0'
               description: 'Per-interval increase in the number of Write I/Os.'
               preprocessing:
-                - type: SIMPLE_CHANGE
+                - type: CHANGE_PER_SECOND
               master_item:
                 key: '.1.3.6.1.4.1.37447.1.2.1.34.[{#SNMPINDEX}]'
               tags:
@@ -1496,7 +1496,7 @@ zabbix_export:
                 - type: MULTIPLIER
                   parameters:
                     - '0.001'
-                - type: SIMPLE_CHANGE
+                - type: CHANGE_PER_SECOND
               master_item:
                 key: '.1.3.6.1.4.1.37447.1.2.1.35.[{#SNMPINDEX}]'
               tags:

--- a/Storage_Devices/Nimble_OS_template.yaml
+++ b/Storage_Devices/Nimble_OS_template.yaml
@@ -1,0 +1,997 @@
+zabbix_export:
+  version: '7.2'
+  template_groups:
+  - uuid: 7c2cb727f85b492d88cd56e17127c64d
+    name: Templates/SAN
+  templates:
+  - uuid: fcf578083ef74cc48ac6eb45eb7a3825
+    template: Nimble OS by SNMP
+    name: Nimble OS by SNMP
+    description: Created after a lot of hard work
+    groups:
+    - name: Templates/SAN
+    items:
+    - uuid: 96c7d67a3e9d4c5fb7807fd8314b2a1e
+      name: Nimble-OS::statTimeEpochSeconds
+      type: SNMP_AGENT
+      snmp_oid: .1.3.6.1.4.1.37447.1.3.1.0
+      key: .1.3.6.1.4.1.37447.1.3.1.0
+      delay: 1m
+      history: 2w
+      trends: '0'
+      units: unixtime
+      description: Time at which the sample was taken, measured in seconds since UNIX
+        epoch.
+      tags:
+      - tag: Application
+        value: Nimble OS
+    - uuid: 0f71cb6f93a045f5b162d5494a5e0477
+      name: Nimble-OS::ioReads
+      type: SNMP_AGENT
+      snmp_oid: .1.3.6.1.4.1.37447.1.3.2.0
+      key: .1.3.6.1.4.1.37447.1.3.2.0
+      delay: 1m
+      history: 2w
+      trends: '0'
+      description: Total cumulative number of Read I/Os (sequential and random).
+      tags:
+      - tag: Application
+        value: Nimble OS
+    - uuid: 1ce2e6fbf7a04a78b89176ac8852456a
+      name: Nimble-OS::ioSeqReads
+      type: SNMP_AGENT
+      snmp_oid: .1.3.6.1.4.1.37447.1.3.3.0
+      key: .1.3.6.1.4.1.37447.1.3.3.0
+      delay: 1m
+      history: 2w
+      trends: '0'
+      description: Total cumulative number of Sequential Read I/Os.
+      tags:
+      - tag: Application
+        value: Nimble OS
+    - uuid: 0866490871724e78ad558bded69910c9
+      name: Nimble-OS::ioWrites
+      type: SNMP_AGENT
+      snmp_oid: .1.3.6.1.4.1.37447.1.3.4.0
+      key: .1.3.6.1.4.1.37447.1.3.4.0
+      delay: 1m
+      history: 2w
+      trends: '0'
+      description: Total cumulative number of Write I/Os.
+      tags:
+      - tag: Application
+        value: Nimble OS
+    - uuid: 54db1958a1e043ed81cc09d9c9730a35
+      name: Nimble-OS::ioSeqWrites
+      type: SNMP_AGENT
+      snmp_oid: .1.3.6.1.4.1.37447.1.3.5.0
+      key: .1.3.6.1.4.1.37447.1.3.5.0
+      delay: 1m
+      history: 2w
+      trends: '0'
+      description: Total cumulative number of Sequential Write I/Os.
+      tags:
+      - tag: Application
+        value: Nimble OS
+    - uuid: f463d114d06d40bfa1aa563399ad6792
+      name: Nimble-OS::ioReadTimeMicrosec
+      type: SNMP_AGENT
+      snmp_oid: .1.3.6.1.4.1.37447.1.3.6.0
+      key: .1.3.6.1.4.1.37447.1.3.6.0
+      delay: 1m
+      history: 2w
+      trends: '0'
+      units: ms
+      description: Total cumulative microseconds the system has spent processing Read
+        I/Os. This includes system and disk latency, but not any network latency back
+        to the initiator.
+      preprocessing:
+        - type: MULTIPLIER
+          parameters:
+            - '0.001'
+        - type: SIMPLE_CHANGE
+      tags:
+      - tag: Application
+        value: Nimble OS
+    - uuid: 79e57c62be894d80a093d395ab995a0b
+      name: Nimble-OS::ioWriteTimeMicrosec
+      type: SNMP_AGENT
+      snmp_oid: .1.3.6.1.4.1.37447.1.3.7.0
+      key: .1.3.6.1.4.1.37447.1.3.7.0
+      delay: 1m
+      history: 2w
+      trends: '0'
+      units: ms
+      description: Total cumulative microseconds the system has spent processing Write
+        I/Os. This includes system and disk latency, but not any network latency back
+        to the initiator.
+      preprocessing:
+        - type: MULTIPLIER
+          parameters:
+            - '0.001'
+        - type: SIMPLE_CHANGE
+      tags:
+      - tag: Application
+        value: Nimble OS
+    - uuid: 661e765a10934c0da170ee902ba509cf
+      name: Nimble-OS::ioReadBytes
+      type: SNMP_AGENT
+      snmp_oid: .1.3.6.1.4.1.37447.1.3.8.0
+      key: .1.3.6.1.4.1.37447.1.3.8.0
+      delay: 1m
+      history: 2w
+      trends: '0'
+      units: B
+      description: Total cumulative number of Read I/O bytes (sequential and random).
+      tags:
+      - tag: Application
+        value: Nimble OS
+    - uuid: c4a5510852cb4da492719eb8e0da5f19
+      name: Nimble-OS::ioSeqReadBytes
+      type: SNMP_AGENT
+      snmp_oid: .1.3.6.1.4.1.37447.1.3.9.0
+      key: .1.3.6.1.4.1.37447.1.3.9.0
+      delay: 1m
+      history: 2w
+      trends: '0'
+      units: B
+      description: Total cumulative number of Sequential Read I/O bytes.
+      tags:
+      - tag: Application
+        value: Nimble OS
+    - uuid: 2351c4d411424eae9fb03bbc42c06500
+      name: Nimble-OS::ioWriteBytes
+      type: SNMP_AGENT
+      snmp_oid: .1.3.6.1.4.1.37447.1.3.10.0
+      key: .1.3.6.1.4.1.37447.1.3.10.0
+      delay: 1m
+      history: 2w
+      trends: '0'
+      units: B
+      description: Total cumulative number of Write I/O bytes (sequential and random).
+      tags:
+      - tag: Application
+        value: Nimble OS
+    - uuid: f5f9ded8ebec43efafd3cfd43f3946db
+      name: Nimble-OS::ioSeqWriteBytes
+      type: SNMP_AGENT
+      snmp_oid: .1.3.6.1.4.1.37447.1.3.11.0
+      key: .1.3.6.1.4.1.37447.1.3.11.0
+      delay: 1m
+      history: 2w
+      trends: '0'
+      units: B
+      description: Total cumulative number of Sequential Write I/O bytes.
+      tags:
+      - tag: Application
+        value: Nimble OS
+    - uuid: 1d66e656c4a7478b93e8264eb59c2425
+      name: Nimble-OS::diskVolBytesUsedLow
+      type: SNMP_AGENT
+      snmp_oid: .1.3.6.1.4.1.37447.1.3.12.0
+      key: .1.3.6.1.4.1.37447.1.3.12.0
+      delay: 1m
+      history: 2w
+      trends: '0'
+      units: B
+      description: Total number of bytes used on disk for volumes - low order bytes.
+      tags:
+      - tag: Application
+        value: Nimble OS
+    - uuid: f1d1faa3ca824b9ba4eb52340c12c50c
+      name: Nimble-OS::diskVolBytesUsedHigh
+      type: SNMP_AGENT
+      snmp_oid: .1.3.6.1.4.1.37447.1.3.13.0
+      key: .1.3.6.1.4.1.37447.1.3.13.0
+      delay: 1m
+      history: 2w
+      trends: '0'
+      units: B
+      description: Total number of bytes used on disk for volumes - high order bytes.
+      tags:
+      - tag: Application
+        value: Nimble OS
+    - uuid: e024111045d74b359950b3d2fb8adc98
+      name: Nimble-OS::diskSnapBytesUsedLow
+      type: SNMP_AGENT
+      snmp_oid: .1.3.6.1.4.1.37447.1.3.14.0
+      key: .1.3.6.1.4.1.37447.1.3.14.0
+      delay: 1m
+      history: 2w
+      trends: '0'
+      units: B
+      description: Total number of bytes used on disk for snapshots - low order bytes.
+      tags:
+      - tag: Application
+        value: Nimble OS
+    - uuid: 543ef43778ba483f804aeae2a8a89de6
+      name: Nimble-OS::diskSnapBytesUsedHigh
+      type: SNMP_AGENT
+      snmp_oid: .1.3.6.1.4.1.37447.1.3.15.0
+      key: .1.3.6.1.4.1.37447.1.3.15.0
+      delay: 1m
+      history: 2w
+      trends: '0'
+      units: B
+      description: Total number of bytes used on disk for snapshots - high order bytes.
+      tags:
+      - tag: Application
+        value: Nimble OS
+    - uuid: 9e626a7aa79147e8ab2c624070fc08a2
+      name: Nimble-OS::ioNonseqReadHits
+      type: SNMP_AGENT
+      snmp_oid: .1.3.6.1.4.1.37447.1.3.16.0
+      key: .1.3.6.1.4.1.37447.1.3.16.0
+      delay: 1m
+      history: 2w
+      value_type: FLOAT
+      trends: '0'
+      description: Total cumulative number of cache hits for Non-Sequential Read I/Os.
+      tags: []
+    discovery_rules:
+    - uuid: a9b613800fb0435cb49630460168995b
+      name: Nimble-OS::volTable
+      type: SNMP_AGENT
+      snmp_oid: discovery[{#VOLID},.1.3.6.1.4.1.37447.1.2.1.2,{#VOLNAME},.1.3.6.1.4.1.37447.1.2.1.3,{#VOLSIZELOW},.1.3.6.1.4.1.37447.1.2.1.4,{#VOLSIZEHIGH},.1.3.6.1.4.1.37447.1.2.1.5,{#VOLUSAGELOW},.1.3.6.1.4.1.37447.1.2.1.6,{#VOLUSAGEHIGH},.1.3.6.1.4.1.37447.1.2.1.7,{#VOLRESERVELOW},.1.3.6.1.4.1.37447.1.2.1.8,{#VOLRESERVEHIGH},.1.3.6.1.4.1.37447.1.2.1.9,{#VOLONLINE},.1.3.6.1.4.1.37447.1.2.1.10,{#VOLNUMCONNECTIONS},.1.3.6.1.4.1.37447.1.2.1.11,{#VOLSTATTIMEEPOCHSECONDS},.1.3.6.1.4.1.37447.1.2.1.12]
+      key: .1.3.6.1.4.1.37447.1.2
+      delay: '3600'
+      lifetime: 30d
+      enabled_lifetime_type: DISABLE_NEVER
+      description: Volume information table.
+      item_prototypes:
+      - uuid: a75f535f2ee04a6cb360ee09b2748b59
+        name: Nimble-OS::volID[{#SNMPINDEX}]
+        type: SNMP_AGENT
+        snmp_oid: .1.3.6.1.4.1.37447.1.2.1.2.{#SNMPINDEX}
+        key: .1.3.6.1.4.1.37447.1.2.1.2.[{#SNMPINDEX}]
+        delay: 1m
+        history: 2w
+        value_type: FLOAT
+        trends: '0'
+        description: Volume ID.
+        tags:
+        - tag: Application
+          value: Nimble OS
+      - uuid: acf8f34817eb497e8b27813b555615d1
+        name: Nimble-OS::volName[{#SNMPINDEX}]
+        type: SNMP_AGENT
+        snmp_oid: .1.3.6.1.4.1.37447.1.2.1.3.{#SNMPINDEX}
+        key: .1.3.6.1.4.1.37447.1.2.1.3.[{#SNMPINDEX}]
+        delay: 1m
+        history: 2w
+        value_type: TEXT
+        description: Volume Name.
+        tags:
+        - tag: Application
+          value: Nimble OS
+      - uuid: ab57e6cd39c14b1a82ad03449777f2e1
+        name: Nimble-OS::volSizeLow[{#SNMPINDEX}]
+        type: SNMP_AGENT
+        snmp_oid: .1.3.6.1.4.1.37447.1.2.1.4.{#SNMPINDEX}
+        key: .1.3.6.1.4.1.37447.1.2.1.4.[{#SNMPINDEX}]
+        delay: 1m
+        history: 2w
+        value_type: FLOAT
+        trends: '0'
+        units: B
+        description: Maximum defined size of a volume in bytes - low order bytes.
+        tags:
+        - tag: Application
+          value: Nimble OS
+      - uuid: 6e04631ec2cd4f869c9db2a7d0ed002b
+        name: Nimble-OS::volSizeHigh[{#SNMPINDEX}]
+        type: SNMP_AGENT
+        snmp_oid: .1.3.6.1.4.1.37447.1.2.1.5.{#SNMPINDEX}
+        key: .1.3.6.1.4.1.37447.1.2.1.5.[{#SNMPINDEX}]
+        delay: 1m
+        history: 2w
+        value_type: FLOAT
+        trends: '0'
+        units: B
+        description: Maximum defined size of a volume in bytes - high order bytes.
+        tags:
+        - tag: Application
+          value: Nimble OS
+      - uuid: b8e0adad6a68480e9a54fc6c266cf787
+        name: Nimble-OS::volUsageLow[{#SNMPINDEX}]
+        type: SNMP_AGENT
+        snmp_oid: .1.3.6.1.4.1.37447.1.2.1.6.{#SNMPINDEX}
+        key: .1.3.6.1.4.1.37447.1.2.1.6.[{#SNMPINDEX}]
+        delay: 1m
+        history: 2w
+        value_type: FLOAT
+        trends: '0'
+        units: B
+        description: Current number of bytes a volume is using - low order bytes.
+        tags:
+        - tag: Application
+          value: Nimble OS
+      - uuid: e2bd9945deb34ee69c281dcc2a76a3d9
+        name: Nimble-OS::volUsageHigh[{#SNMPINDEX}]
+        type: SNMP_AGENT
+        snmp_oid: .1.3.6.1.4.1.37447.1.2.1.7.{#SNMPINDEX}
+        key: .1.3.6.1.4.1.37447.1.2.1.7.[{#SNMPINDEX}]
+        delay: 1m
+        history: 2w
+        value_type: FLOAT
+        trends: '0'
+        units: B
+        description: Current number of bytes a volume is using - high order bytes.
+        tags:
+        - tag: Application
+          value: Nimble OS
+      - uuid: 1a05c86a222f46d6800df6b14af75a6a
+        name: Nimble-OS::volReserveLow[{#SNMPINDEX}]
+        type: SNMP_AGENT
+        snmp_oid: .1.3.6.1.4.1.37447.1.2.1.8.{#SNMPINDEX}
+        key: .1.3.6.1.4.1.37447.1.2.1.8.[{#SNMPINDEX}]
+        delay: 1m
+        history: 2w
+        value_type: FLOAT
+        trends: '0'
+        units: B
+        description: Number of bytes reserved for a volume - low order bytes.
+        tags:
+        - tag: Application
+          value: Nimble OS
+      - uuid: 4fb41824305e424bb471da9473d2baec
+        name: Nimble-OS::volReserveHigh[{#SNMPINDEX}]
+        type: SNMP_AGENT
+        snmp_oid: .1.3.6.1.4.1.37447.1.2.1.9.{#SNMPINDEX}
+        key: .1.3.6.1.4.1.37447.1.2.1.9.[{#SNMPINDEX}]
+        delay: 1m
+        history: 2w
+        value_type: FLOAT
+        trends: '0'
+        units: B
+        description: Number of bytes reserved for a volume - high order bytes.
+        tags:
+        - tag: Application
+          value: Nimble OS
+      - uuid: 9e68c0df6c3245a7a9e5aee12c4b9875
+        name: Nimble-OS::volOnline[{#SNMPINDEX}]
+        type: SNMP_AGENT
+        snmp_oid: .1.3.6.1.4.1.37447.1.2.1.10.{#SNMPINDEX}
+        key: .1.3.6.1.4.1.37447.1.2.1.10.[{#SNMPINDEX}]
+        delay: 1m
+        history: 2w
+        value_type: FLOAT
+        trends: '0'
+        description: Volume Online (true or false).
+        valuemap:
+          name: Nimble-OS::volOnline
+        tags:
+        - tag: Application
+          value: Nimble OS
+      - uuid: aa14fd14fa5e4e81afeca9a54c2c4c1d
+        name: Nimble-OS::volNumConnections[{#SNMPINDEX}]
+        type: SNMP_AGENT
+        snmp_oid: .1.3.6.1.4.1.37447.1.2.1.11.{#SNMPINDEX}
+        key: .1.3.6.1.4.1.37447.1.2.1.11.[{#SNMPINDEX}]
+        delay: 1m
+        history: 2w
+        value_type: FLOAT
+        trends: '0'
+        description: Number of iSCSI connections to the volume.
+        tags:
+        - tag: Application
+          value: Nimble OS
+      - uuid: 41cf08abb9f54c56a9679cf584c4e405
+        name: Nimble-OS::volStatTimeEpochSeconds[{#SNMPINDEX}]
+        type: SNMP_AGENT
+        snmp_oid: .1.3.6.1.4.1.37447.1.2.1.12.{#SNMPINDEX}
+        key: .1.3.6.1.4.1.37447.1.2.1.12.[{#SNMPINDEX}]
+        delay: 1m
+        history: 2w
+        units: unixtime
+        value_type: FLOAT
+        description: Time at which the sample was taken, measured in seconds since
+          UNIX epoch.
+        tags:
+        - tag: Application
+          value: Nimble OS
+      - uuid: 3eb16a72d27741ce9ae915deec5f3133
+        name: Nimble-OS::volIoReads[{#SNMPINDEX}]
+        type: SNMP_AGENT
+        snmp_oid: .1.3.6.1.4.1.37447.1.2.1.13.{#SNMPINDEX}
+        key: .1.3.6.1.4.1.37447.1.2.1.13.[{#SNMPINDEX}]
+        delay: 1m
+        history: 2w
+        value_type: FLOAT
+        trends: '0'
+        description: Total cumulative number of Read I/Os (sequential and random).
+        tags:
+        - tag: Application
+          value: Nimble OS
+      - uuid: 9957a27e857e48588a3aff460f3c3c2a
+        name: Nimble-OS::volIoReadTimeMicrosec[{#SNMPINDEX}]
+        type: SNMP_AGENT
+        snmp_oid: .1.3.6.1.4.1.37447.1.2.1.14.{#SNMPINDEX}
+        key: .1.3.6.1.4.1.37447.1.2.1.14.[{#SNMPINDEX}]
+        delay: 1m
+        history: 2w
+        value_type: FLOAT
+        trends: '0'
+        units: ms
+        description: Total cumulative time for Read operation (sequential and random).
+        preprocessing:
+        - type: MULTIPLIER
+          parameters:
+            - '0.001'
+        - type: SIMPLE_CHANGE
+        tags:
+        - tag: Application
+          value: Nimble OS
+      - uuid: a681f67fae74473d94b8a48fd716cc87
+        name: Nimble-OS::volIoReadBytes[{#SNMPINDEX}]
+        type: SNMP_AGENT
+        snmp_oid: .1.3.6.1.4.1.37447.1.2.1.15.{#SNMPINDEX}
+        key: .1.3.6.1.4.1.37447.1.2.1.15.[{#SNMPINDEX}]
+        delay: 1m
+        history: 2w
+        value_type: FLOAT
+        trends: '0'
+        units: B
+        description: Total cumulative number of Read I/O bytes (sequential and random).
+        tags:
+        - tag: Application
+          value: Nimble OS
+      - uuid: efa037550902496c995ab5ddd27c0908
+        name: Nimble-OS::volIoSeqReads[{#SNMPINDEX}]
+        type: SNMP_AGENT
+        snmp_oid: .1.3.6.1.4.1.37447.1.2.1.16.{#SNMPINDEX}
+        key: .1.3.6.1.4.1.37447.1.2.1.16.[{#SNMPINDEX}]
+        delay: 1m
+        history: 2w
+        value_type: FLOAT
+        trends: '0'
+        description: Total Number of Sequential Read I/O operations.
+        tags:
+        - tag: Application
+          value: Nimble OS
+      - uuid: f322715c64294d63996527813d5f5859
+        name: Nimble-OS::volIoSeqReadBytes[{#SNMPINDEX}]
+        type: SNMP_AGENT
+        snmp_oid: .1.3.6.1.4.1.37447.1.2.1.17.{#SNMPINDEX}
+        key: .1.3.6.1.4.1.37447.1.2.1.17.[{#SNMPINDEX}]
+        delay: 1m
+        history: 2w
+        value_type: FLOAT
+        trends: '0'
+        units: B
+        description: Total cumulative number of Sequential Read I/O bytes.
+        tags:
+        - tag: Application
+          value: Nimble OS
+      - uuid: 04f31e9b0a434c80ad59f1272f1bda74
+        name: Nimble-OS::volIoNonseqReadTotalHits[{#SNMPINDEX}]
+        type: SNMP_AGENT
+        snmp_oid: .1.3.6.1.4.1.37447.1.2.1.18.{#SNMPINDEX}
+        key: .1.3.6.1.4.1.37447.1.2.1.18.[{#SNMPINDEX}]
+        delay: 1m
+        history: 2w
+        value_type: FLOAT
+        description: Total number of Nonsequential Read I/O hits (to Memory and SSD).
+        tags:
+        - tag: Application
+          value: Nimble OS
+      - uuid: c30f6388046f41449842ca573fb28a2f
+        name: Nimble-OS::volIoNonseqReadMemHits[{#SNMPINDEX}]
+        type: SNMP_AGENT
+        snmp_oid: .1.3.6.1.4.1.37447.1.2.1.19.{#SNMPINDEX}
+        key: .1.3.6.1.4.1.37447.1.2.1.19.[{#SNMPINDEX}]
+        delay: 1m
+        history: 2w
+        value_type: FLOAT
+        trends: '0'
+        description: Total number of Nonsequential Read I/O hits to Memory.
+        tags:
+        - tag: Application
+          value: Nimble OS
+      - uuid: eff76e80740846fba7459d040cce8d73
+        name: Nimble-OS::volIoNonseqReadSSDHits[{#SNMPINDEX}]
+        type: SNMP_AGENT
+        snmp_oid: .1.3.6.1.4.1.37447.1.2.1.20.{#SNMPINDEX}
+        key: .1.3.6.1.4.1.37447.1.2.1.20.[{#SNMPINDEX}]
+        delay: 1m
+        history: 2w
+        value_type: FLOAT
+        trends: '0'
+        description: Total number of Nonsequential Read I/O hits to SSD.
+        tags:
+        - tag: Application
+          value: Nimble OS
+      - uuid: 44ce809f8ea540a29bdfa6e2d6f3c212
+        name: Nimble-OS::volIoReadLatency0uTo100u[{#SNMPINDEX}]
+        type: SNMP_AGENT
+        snmp_oid: .1.3.6.1.4.1.37447.1.2.1.21.{#SNMPINDEX}
+        key: .1.3.6.1.4.1.37447.1.2.1.21.[{#SNMPINDEX}]
+        delay: 1m
+        history: 2w
+        value_type: FLOAT
+        trends: '0'
+        description: Number of Read I/O operations with latency between 0 and 100
+          microseconds.
+        tags:
+        - tag: Application
+          value: Nimble OS
+      - uuid: 0595148f41a046ef9f3ca40a88525b46
+        name: Nimble-OS::volIoReadLatency100uTo200u[{#SNMPINDEX}]
+        type: SNMP_AGENT
+        snmp_oid: .1.3.6.1.4.1.37447.1.2.1.22.{#SNMPINDEX}
+        key: .1.3.6.1.4.1.37447.1.2.1.22.[{#SNMPINDEX}]
+        delay: 1m
+        history: 2w
+        value_type: FLOAT
+        trends: '0'
+        description: Number of Read I/O operations with latency between 100 and 200
+          microseconds.
+        tags:
+        - tag: Application
+          value: Nimble OS
+      - uuid: 184c0025750d4d35b5d62d4e44631455
+        name: Nimble-OS::volIoReadLatency200uTo500u[{#SNMPINDEX}]
+        type: SNMP_AGENT
+        snmp_oid: .1.3.6.1.4.1.37447.1.2.1.23.{#SNMPINDEX}
+        key: .1.3.6.1.4.1.37447.1.2.1.23.[{#SNMPINDEX}]
+        delay: 1m
+        history: 2w
+        value_type: FLOAT
+        trends: '0'
+        description: Number of Read I/O operations with latency between 200 and 500
+          microseconds.
+        tags:
+        - tag: Application
+          value: Nimble OS
+      - uuid: c2946abd5cea443784c239b70645e3ca
+        name: Nimble-OS::volIoReadLatency500uTo1m[{#SNMPINDEX}]
+        type: SNMP_AGENT
+        snmp_oid: .1.3.6.1.4.1.37447.1.2.1.24.{#SNMPINDEX}
+        key: .1.3.6.1.4.1.37447.1.2.1.24.[{#SNMPINDEX}]
+        delay: 1m
+        history: 2w
+        value_type: FLOAT
+        trends: '0'
+        description: Number of Read I/O operations with latency between 1/2 and 1
+          milliseconds.
+        tags:
+        - tag: Application
+          value: Nimble OS
+      - uuid: f3d1c4f3b7fa4bc6ba3f3bdcf5271118
+        name: Nimble-OS::volIoReadLatency1mTo2m[{#SNMPINDEX}]
+        type: SNMP_AGENT
+        snmp_oid: .1.3.6.1.4.1.37447.1.2.1.25.{#SNMPINDEX}
+        key: .1.3.6.1.4.1.37447.1.2.1.25.[{#SNMPINDEX}]
+        delay: 1m
+        history: 2w
+        value_type: FLOAT
+        trends: '0'
+        description: Number of Read I/O operations with latency between 1 and 2 milliseconds.
+        tags:
+        - tag: Application
+          value: Nimble OS
+      - uuid: a17a78edaf8e4434bd76c1029099d99d
+        name: Nimble-OS::volIoReadLatency2mTo5m[{#SNMPINDEX}]
+        type: SNMP_AGENT
+        snmp_oid: .1.3.6.1.4.1.37447.1.2.1.26.{#SNMPINDEX}
+        key: .1.3.6.1.4.1.37447.1.2.1.26.[{#SNMPINDEX}]
+        delay: 1m
+        history: 2w
+        value_type: FLOAT
+        trends: '0'
+        description: Number of Read I/O operations with latency between 2 and 5 milliseconds.
+        tags:
+        - tag: Application
+          value: Nimble OS
+      - uuid: 197c95ba262f4829a12ac82b0d74b200
+        name: Nimble-OS::volIoReadLatency5mTo10m[{#SNMPINDEX}]
+        type: SNMP_AGENT
+        snmp_oid: .1.3.6.1.4.1.37447.1.2.1.27.{#SNMPINDEX}
+        key: .1.3.6.1.4.1.37447.1.2.1.27.[{#SNMPINDEX}]
+        delay: 1m
+        history: 2w
+        value_type: FLOAT
+        trends: '0'
+        description: Number of Read I/O operations with latency between 5 and 10 milliseconds.
+        tags:
+        - tag: Application
+          value: Nimble OS
+      - uuid: 5776ada41ee44f89bdc936041df4fa5e
+        name: Nimble-OS::volIoReadLatency10mTo20m[{#SNMPINDEX}]
+        type: SNMP_AGENT
+        snmp_oid: .1.3.6.1.4.1.37447.1.2.1.28.{#SNMPINDEX}
+        key: .1.3.6.1.4.1.37447.1.2.1.28.[{#SNMPINDEX}]
+        delay: 1m
+        history: 2w
+        value_type: FLOAT
+        trends: '0'
+        description: Number of Read I/O operations with latency between 10 and 20
+          milliseconds.
+        tags:
+        - tag: Application
+          value: Nimble OS
+      - uuid: 8ab9839beb374963a787a386355e62ef
+        name: Nimble-OS::volIoReadLatency20mTo50m[{#SNMPINDEX}]
+        type: SNMP_AGENT
+        snmp_oid: .1.3.6.1.4.1.37447.1.2.1.29.{#SNMPINDEX}
+        key: .1.3.6.1.4.1.37447.1.2.1.29.[{#SNMPINDEX}]
+        delay: 1m
+        history: 2w
+        value_type: FLOAT
+        trends: '0'
+        description: Number of Read I/O operations with latency between 20 and 50
+          milliseconds.
+        tags:
+        - tag: Application
+          value: Nimble OS
+      - uuid: 377346e621854ceb979ae87bbb54bc01
+        name: Nimble-OS::volIoReadLatency50mTo100m[{#SNMPINDEX}]
+        type: SNMP_AGENT
+        snmp_oid: .1.3.6.1.4.1.37447.1.2.1.30.{#SNMPINDEX}
+        key: .1.3.6.1.4.1.37447.1.2.1.30.[{#SNMPINDEX}]
+        delay: 1m
+        history: 2w
+        value_type: FLOAT
+        trends: '0'
+        description: Number of Read I/O operations with latency between 50 and 100
+          milliseconds.
+        tags:
+        - tag: Application
+          value: Nimble OS
+      - uuid: 909932ad797d47828f667475235a16a7
+        name: Nimble-OS::volIoReadLatency100mTo200m[{#SNMPINDEX}]
+        type: SNMP_AGENT
+        snmp_oid: .1.3.6.1.4.1.37447.1.2.1.31.{#SNMPINDEX}
+        key: .1.3.6.1.4.1.37447.1.2.1.31.[{#SNMPINDEX}]
+        delay: 1m
+        history: 2w
+        value_type: FLOAT
+        trends: '0'
+        description: Number of Read I/O operations with latency between 100 and 200
+          milliseconds.
+        tags:
+        - tag: Application
+          value: Nimble OS
+      - uuid: c1d0af8d0ff849f785a36bb325161851
+        name: Nimble-OS::volIoReadLatency200mTo500m[{#SNMPINDEX}]
+        type: SNMP_AGENT
+        snmp_oid: .1.3.6.1.4.1.37447.1.2.1.32.{#SNMPINDEX}
+        key: .1.3.6.1.4.1.37447.1.2.1.32.[{#SNMPINDEX}]
+        delay: 1m
+        history: 2w
+        value_type: FLOAT
+        trends: '0'
+        description: Number of Read I/O operations with latency between 200 and 500
+          milliseconds.
+        tags:
+        - tag: Application
+          value: Nimble OS
+      - uuid: d0c488891ef541d8b8badc4565c33f0e
+        name: Nimble-OS::volIoReadLatency500mTomax[{#SNMPINDEX}]
+        type: SNMP_AGENT
+        snmp_oid: .1.3.6.1.4.1.37447.1.2.1.33.{#SNMPINDEX}
+        key: .1.3.6.1.4.1.37447.1.2.1.33.[{#SNMPINDEX}]
+        delay: 1m
+        history: 2w
+        value_type: FLOAT
+        trends: '0'
+        description: Number of Read I/O operations with latency above 500 milliseconds.
+        tags:
+        - tag: Application
+          value: Nimble OS
+      - uuid: b884f037aaa144a9b40084321aa618cb
+        name: Nimble-OS::volIoWrites[{#SNMPINDEX}]
+        type: SNMP_AGENT
+        snmp_oid: .1.3.6.1.4.1.37447.1.2.1.34.{#SNMPINDEX}
+        key: .1.3.6.1.4.1.37447.1.2.1.34.[{#SNMPINDEX}]
+        delay: 1m
+        history: 2w
+        value_type: FLOAT
+        description: Total cumulative number of Write I/Os.
+        tags:
+        - tag: Application
+          value: Nimble OS
+      - uuid: e959f7cc290f4b6eba18451a2b9c18bb
+        name: Nimble-OS::volIoWriteTimeMicrosec[{#SNMPINDEX}]
+        type: SNMP_AGENT
+        snmp_oid: .1.3.6.1.4.1.37447.1.2.1.35.{#SNMPINDEX}
+        key: .1.3.6.1.4.1.37447.1.2.1.35.[{#SNMPINDEX}]
+        delay: 1m
+        history: 2w
+        units: ms
+        value_type: FLOAT
+        description: Total cumulative time for Write operation (sequential and random).
+        tags:
+        - tag: Application
+          value: Nimble OS
+      - uuid: cb4ded6313264ea3933613a6a59328e0
+        name: Nimble-OS::volIoWriteBytes[{#SNMPINDEX}]
+        type: SNMP_AGENT
+        snmp_oid: .1.3.6.1.4.1.37447.1.2.1.36.{#SNMPINDEX}
+        key: .1.3.6.1.4.1.37447.1.2.1.36.[{#SNMPINDEX}]
+        delay: 1m
+        history: 2w
+        value_type: FLOAT
+        trends: '0'
+        units: B
+        description: Total cumulative number of Write I/O bytes (sequential and random).
+        tags:
+        - tag: Application
+          value: Nimble OS
+      - uuid: 0ae806181724465bbe0424f6883f5ccb
+        name: Nimble-OS::volIoSeqWrites[{#SNMPINDEX}]
+        type: SNMP_AGENT
+        snmp_oid: .1.3.6.1.4.1.37447.1.2.1.37.{#SNMPINDEX}
+        key: .1.3.6.1.4.1.37447.1.2.1.37.[{#SNMPINDEX}]
+        delay: 1m
+        history: 2w
+        value_type: FLOAT
+        trends: '0'
+        description: Total Number of Sequential Write I/O operations.
+        tags:
+        - tag: Application
+          value: Nimble OS
+      - uuid: 726e18eb993a48aab100c27135b66502
+        name: Nimble-OS::volIoSeqWriteBytes[{#SNMPINDEX}]
+        type: SNMP_AGENT
+        snmp_oid: .1.3.6.1.4.1.37447.1.2.1.38.{#SNMPINDEX}
+        key: .1.3.6.1.4.1.37447.1.2.1.38.[{#SNMPINDEX}]
+        delay: 1m
+        history: 2w
+        value_type: FLOAT
+        trends: '0'
+        units: B
+        description: Number of Sequential Write I/O bytes.
+        tags:
+        - tag: Application
+          value: Nimble OS
+      - uuid: f3c81524a29945fb827d3047284428d5
+        name: Nimble-OS::volIoWriteLatency0uTo100u[{#SNMPINDEX}]
+        type: SNMP_AGENT
+        snmp_oid: .1.3.6.1.4.1.37447.1.2.1.39.{#SNMPINDEX}
+        key: .1.3.6.1.4.1.37447.1.2.1.39.[{#SNMPINDEX}]
+        delay: 1m
+        history: 2w
+        value_type: FLOAT
+        trends: '0'
+        description: Number of Write I/O operations with latency between 0 and 100
+          microseconds.
+        tags:
+        - tag: Application
+          value: Nimble OS
+      - uuid: ec1fdf6ecd904a55bf47d808baece0fe
+        name: Nimble-OS::volIoWriteLatency100uTo200u[{#SNMPINDEX}]
+        type: SNMP_AGENT
+        snmp_oid: .1.3.6.1.4.1.37447.1.2.1.40.{#SNMPINDEX}
+        key: .1.3.6.1.4.1.37447.1.2.1.40.[{#SNMPINDEX}]
+        delay: 1m
+        history: 2w
+        value_type: FLOAT
+        trends: '0'
+        description: Number of Write I/O operations with latency between 100 and 200
+        tags:
+        - tag: Application
+          value: Nimble OS
+      - uuid: cf4ac1bf942843cfacc571555f646937
+        name: Nimble-OS::volIoWriteLatency200uTo500u[{#SNMPINDEX}]
+        type: SNMP_AGENT
+        snmp_oid: .1.3.6.1.4.1.37447.1.2.1.41.{#SNMPINDEX}
+        key: .1.3.6.1.4.1.37447.1.2.1.41.[{#SNMPINDEX}]
+        delay: 1m
+        history: 2w
+        value_type: FLOAT
+        trends: '0'
+        description: Number of Write I/O operations with latency between 200 and 500
+          microseconds.
+        tags:
+        - tag: Application
+          value: Nimble OS
+      - uuid: c1a01cb349ff454792f0984dbd161494
+        name: Nimble-OS::volIoWriteLatency500uTo1m[{#SNMPINDEX}]
+        type: SNMP_AGENT
+        snmp_oid: .1.3.6.1.4.1.37447.1.2.1.42.{#SNMPINDEX}
+        key: .1.3.6.1.4.1.37447.1.2.1.42.[{#SNMPINDEX}]
+        delay: 1m
+        history: 2w
+        value_type: FLOAT
+        description: Number of Write I/O operations with latency between 1/2 and 1
+          milliseconds.
+        tags:
+        - tag: Application
+          value: Nimble OS
+      - uuid: 25323e43edf54d308b2e3f2c4f77d343
+        name: Nimble-OS::volIoWriteLatency1mTo2m[{#SNMPINDEX}]
+        type: SNMP_AGENT
+        snmp_oid: .1.3.6.1.4.1.37447.1.2.1.43.{#SNMPINDEX}
+        key: .1.3.6.1.4.1.37447.1.2.1.43.[{#SNMPINDEX}]
+        delay: 1m
+        history: 2w
+        value_type: FLOAT
+        trends: '0'
+        description: Number of Write I/O operations with latency between 1 and 2 milliseconds.
+        tags:
+        - tag: Application
+          value: Nimble OS
+      - uuid: 288eac5a74454570b740c20f63738103
+        name: Nimble-OS::volIoWriteLatency2mTo5m[{#SNMPINDEX}]
+        type: SNMP_AGENT
+        snmp_oid: .1.3.6.1.4.1.37447.1.2.1.44.{#SNMPINDEX}
+        key: .1.3.6.1.4.1.37447.1.2.1.44.[{#SNMPINDEX}]
+        delay: 1m
+        history: 2w
+        value_type: FLOAT
+        trends: '0'
+        description: Number of Write I/O operations with latency between 2 and 5 milliseconds.
+        tags:
+        - tag: Application
+          value: Nimble OS
+      - uuid: 3993c03618e2429290e8e96b619713e0
+        name: Nimble-OS::volIoWriteLatency5mTo10m[{#SNMPINDEX}]
+        type: SNMP_AGENT
+        snmp_oid: .1.3.6.1.4.1.37447.1.2.1.45.{#SNMPINDEX}
+        key: .1.3.6.1.4.1.37447.1.2.1.45.[{#SNMPINDEX}]
+        delay: 1m
+        history: 2w
+        value_type: FLOAT
+        trends: '0'
+        description: Number of Write I/O operations with latency between 5 and 10
+          milliseconds.
+        tags:
+        - tag: Application
+          value: Nimble OS
+      - uuid: 197921ca1b2441d08856f3d317084138
+        name: Nimble-OS::volIoWriteLatency10mTo20m[{#SNMPINDEX}]
+        type: SNMP_AGENT
+        snmp_oid: .1.3.6.1.4.1.37447.1.2.1.46.{#SNMPINDEX}
+        key: .1.3.6.1.4.1.37447.1.2.1.46.[{#SNMPINDEX}]
+        delay: 1m
+        history: 2w
+        value_type: FLOAT
+        trends: '0'
+        description: Number of Write I/O operations with latency between 10 and 20
+          milliseconds.
+        tags:
+        - tag: Application
+          value: Nimble OS
+      - uuid: 22c96dc33f074c27adb0f528e1537307
+        name: Nimble-OS::volIoWriteLatency20mTo50m[{#SNMPINDEX}]
+        type: SNMP_AGENT
+        snmp_oid: .1.3.6.1.4.1.37447.1.2.1.47.{#SNMPINDEX}
+        key: .1.3.6.1.4.1.37447.1.2.1.47.[{#SNMPINDEX}]
+        delay: 1m
+        history: 2w
+        value_type: FLOAT
+        trends: '0'
+        description: Number of Write I/O operations with latency between 20 and 50
+          milliseconds.
+        tags:
+        - tag: Application
+          value: Nimble OS
+      - uuid: 5ded4f137ced4e98b48f44ad3a4573d4
+        name: Nimble-OS::volIoWriteLatency50mTo100m[{#SNMPINDEX}]
+        type: SNMP_AGENT
+        snmp_oid: .1.3.6.1.4.1.37447.1.2.1.48.{#SNMPINDEX}
+        key: .1.3.6.1.4.1.37447.1.2.1.48.[{#SNMPINDEX}]
+        delay: 1m
+        history: 2w
+        value_type: FLOAT
+        trends: '0'
+        description: Number of Write I/O operations with latency between 50 and 100
+          milliseconds.
+        tags:
+        - tag: Application
+          value: Nimble OS
+      - uuid: 6fdce410a8c143b68bc55009044271d3
+        name: Nimble-OS::volIoWriteLatency100mTo200m[{#SNMPINDEX}]
+        type: SNMP_AGENT
+        snmp_oid: .1.3.6.1.4.1.37447.1.2.1.49.{#SNMPINDEX}
+        key: .1.3.6.1.4.1.37447.1.2.1.49.[{#SNMPINDEX}]
+        delay: 1m
+        history: 2w
+        value_type: FLOAT
+        trends: '0'
+        description: Number of Write I/O operations with latency between 100 and 200
+          milliseconds.
+        tags:
+        - tag: Application
+          value: Nimble OS
+      - uuid: 1db071e1f47c42fb8917b3e0b08d8abb
+        name: Nimble-OS::volIoWriteLatency200mTo500m[{#SNMPINDEX}]
+        type: SNMP_AGENT
+        snmp_oid: .1.3.6.1.4.1.37447.1.2.1.50.{#SNMPINDEX}
+        key: .1.3.6.1.4.1.37447.1.2.1.50.[{#SNMPINDEX}]
+        delay: 1m
+        history: 2w
+        value_type: FLOAT
+        trends: '0'
+        description: Number of Write I/O operations with latency between 200 and 500
+          milliseconds.
+        tags:
+        - tag: Application
+          value: Nimble OS
+      - uuid: 0e5ef32270814e3d91aac2b01faac6be
+        name: Nimble-OS::volIoWriteLatency500mTomax[{#SNMPINDEX}]
+        type: SNMP_AGENT
+        snmp_oid: .1.3.6.1.4.1.37447.1.2.1.51.{#SNMPINDEX}
+        key: .1.3.6.1.4.1.37447.1.2.1.51.[{#SNMPINDEX}]
+        delay: 1m
+        history: 2w
+        value_type: FLOAT
+        trends: '0'
+        description: Number of Write I/O operations with latency above 500 milliseconds.
+        tags:
+        - tag: Application
+          value: Nimble OS
+      - uuid: a17c6405c9a749d3b2838542e89f3ebb
+        name: Nimble-OS::volDiskVolBytesUsedLow[{#SNMPINDEX}]
+        type: SNMP_AGENT
+        snmp_oid: .1.3.6.1.4.1.37447.1.2.1.52.{#SNMPINDEX}
+        key: .1.3.6.1.4.1.37447.1.2.1.52.[{#SNMPINDEX}]
+        delay: 1m
+        history: 2w
+        trends: '0'
+        units: B
+        description: Total number of bytes used on disk for volumes - low order bytes.
+        tags:
+        - tag: Application
+          value: Nimble OS
+      - uuid: 6c1a0136562742519c086630e0d281f3
+        name: Nimble-OS::volDiskVolBytesUsedHigh[{#SNMPINDEX}]
+        type: SNMP_AGENT
+        snmp_oid: .1.3.6.1.4.1.37447.1.2.1.53.{#SNMPINDEX}
+        key: .1.3.6.1.4.1.37447.1.2.1.53.[{#SNMPINDEX}]
+        delay: 1m
+        history: 2w
+        value_type: FLOAT
+        trends: '0'
+        units: B
+        description: Total number of bytes used on disk for volumes - high order bytes.
+        tags:
+        - tag: Application
+          value: Nimble OS
+      - uuid: 766124d2feba490ab901c08d098fb8de
+        name: Nimble-OS::volDiskSnapBytesUsedLow[{#SNMPINDEX}]
+        type: SNMP_AGENT
+        snmp_oid: .1.3.6.1.4.1.37447.1.2.1.54.{#SNMPINDEX}
+        key: .1.3.6.1.4.1.37447.1.2.1.54.[{#SNMPINDEX}]
+        delay: 1m
+        history: 2w
+        value_type: FLOAT
+        trends: '0'
+        units: B
+        description: Total number of bytes used on disk for snapshots - low order
+          bytes.
+        tags:
+        - tag: Application
+          value: Nimble OS
+      - uuid: 67f1ca591cfc486a8a7b0ab7a2c1255d
+        name: Nimble-OS::volDiskSnapBytesUsedHigh[{#SNMPINDEX}]
+        type: SNMP_AGENT
+        snmp_oid: .1.3.6.1.4.1.37447.1.2.1.55.{#SNMPINDEX}
+        key: .1.3.6.1.4.1.37447.1.2.1.55.[{#SNMPINDEX}]
+        delay: 1m
+        history: 2w
+        value_type: FLOAT
+        trends: '0'
+        units: B
+        description: Total number of bytes used on disk for snapshots - high order
+          bytes.
+        tags:
+        - tag: Application
+          value: Nimble OS
+    tags:
+    - tag: class
+      value: storage
+    - tag: target
+      value: Nimble OS
+    macros:
+    - macro: '{$SNMP_PORT}'
+      value: '161'
+    valuemaps:
+    - uuid: 48874c746d7e48dea5941b4c5d62aad7
+      name: Nimble-OS::volOnline
+      mappings:
+      - value: '1'
+        newvalue: 'true'
+      - value: '2'
+        newvalue: 'false'

--- a/Storage_Devices/Nimble_OS_template.yaml
+++ b/Storage_Devices/Nimble_OS_template.yaml
@@ -1,997 +1,1520 @@
 zabbix_export:
   version: '7.2'
   template_groups:
-  - uuid: 7c2cb727f85b492d88cd56e17127c64d
-    name: Templates/SAN
+    - uuid: 7c2cb727f85b492d88cd56e17127c64d
+      name: Templates/SAN
   templates:
-  - uuid: fcf578083ef74cc48ac6eb45eb7a3825
-    template: Nimble OS by SNMP
-    name: Nimble OS by SNMP
-    description: Created after a lot of hard work
-    groups:
-    - name: Templates/SAN
-    items:
-    - uuid: 96c7d67a3e9d4c5fb7807fd8314b2a1e
-      name: Nimble-OS::statTimeEpochSeconds
-      type: SNMP_AGENT
-      snmp_oid: .1.3.6.1.4.1.37447.1.3.1.0
-      key: .1.3.6.1.4.1.37447.1.3.1.0
-      delay: 1m
-      history: 2w
-      trends: '0'
-      units: unixtime
-      description: Time at which the sample was taken, measured in seconds since UNIX
-        epoch.
+    - uuid: fcf578083ef74cc48ac6eb45eb7a3825
+      template: 'Nimble OS by SNMP'
+      name: 'Nimble OS by SNMP'
+      description: 'Created after a lot of hard work'
+      groups:
+        - name: Templates/SAN
+      items:
+        - uuid: 96c7d67a3e9d4c5fb7807fd8314b2a1e
+          name: 'Nimble-OS::statTimeEpochSeconds'
+          type: SNMP_AGENT
+          snmp_oid: .1.3.6.1.4.1.37447.1.3.1.0
+          key: .1.3.6.1.4.1.37447.1.3.1.0
+          history: 2w
+          trends: '0'
+          units: unixtime
+          description: 'Time at which the sample was taken, measured in seconds since UNIX epoch.'
+          tags:
+            - tag: Application
+              value: 'Nimble OS'
+        - uuid: 0f71cb6f93a045f5b162d5494a5e0477
+          name: 'Nimble-OS::ioReads'
+          type: SNMP_AGENT
+          snmp_oid: .1.3.6.1.4.1.37447.1.3.2.0
+          key: .1.3.6.1.4.1.37447.1.3.2.0
+          history: 2w
+          trends: '0'
+          description: 'Total cumulative number of Read I/Os (sequential and random).'
+          tags:
+            - tag: Application
+              value: 'Nimble OS'
+        - uuid: 1ce2e6fbf7a04a78b89176ac8852456a
+          name: 'Nimble-OS::ioSeqReads'
+          type: SNMP_AGENT
+          snmp_oid: .1.3.6.1.4.1.37447.1.3.3.0
+          key: .1.3.6.1.4.1.37447.1.3.3.0
+          history: 2w
+          trends: '0'
+          description: 'Total cumulative number of Sequential Read I/Os.'
+          tags:
+            - tag: Application
+              value: 'Nimble OS'
+        - uuid: 0866490871724e78ad558bded69910c9
+          name: 'Nimble-OS::ioWrites'
+          type: SNMP_AGENT
+          snmp_oid: .1.3.6.1.4.1.37447.1.3.4.0
+          key: .1.3.6.1.4.1.37447.1.3.4.0
+          history: 2w
+          trends: '0'
+          description: 'Total cumulative number of Write I/Os.'
+          tags:
+            - tag: Application
+              value: 'Nimble OS'
+        - uuid: 54db1958a1e043ed81cc09d9c9730a35
+          name: 'Nimble-OS::ioSeqWrites'
+          type: SNMP_AGENT
+          snmp_oid: .1.3.6.1.4.1.37447.1.3.5.0
+          key: .1.3.6.1.4.1.37447.1.3.5.0
+          history: 2w
+          trends: '0'
+          description: 'Total cumulative number of Sequential Write I/Os.'
+          tags:
+            - tag: Application
+              value: 'Nimble OS'
+        - uuid: f463d114d06d40bfa1aa563399ad6792
+          name: 'Nimble-OS::ioReadTimeMicrosec'
+          type: SNMP_AGENT
+          snmp_oid: .1.3.6.1.4.1.37447.1.3.6.0
+          key: .1.3.6.1.4.1.37447.1.3.6.0
+          history: 2w
+          trends: '0'
+          units: ms
+          description: 'Total cumulative microseconds the system has spent processing Read I/Os. This includes system and disk latency, but not any network latency back to the initiator.'
+          preprocessing:
+            - type: MULTIPLIER
+              parameters:
+                - '0.001'
+            - type: SIMPLE_CHANGE
+          tags:
+            - tag: Application
+              value: 'Nimble OS'
+        - uuid: 79e57c62be894d80a093d395ab995a0b
+          name: 'Nimble-OS::ioWriteTimeMicrosec'
+          type: SNMP_AGENT
+          snmp_oid: .1.3.6.1.4.1.37447.1.3.7.0
+          key: .1.3.6.1.4.1.37447.1.3.7.0
+          history: 2w
+          trends: '0'
+          units: ms
+          description: 'Total cumulative microseconds the system has spent processing Write I/Os. This includes system and disk latency, but not any network latency back to the initiator.'
+          preprocessing:
+            - type: MULTIPLIER
+              parameters:
+                - '0.001'
+            - type: SIMPLE_CHANGE
+          tags:
+            - tag: Application
+              value: 'Nimble OS'
+        - uuid: 661e765a10934c0da170ee902ba509cf
+          name: 'Nimble-OS::ioReadBytes'
+          type: SNMP_AGENT
+          snmp_oid: .1.3.6.1.4.1.37447.1.3.8.0
+          key: .1.3.6.1.4.1.37447.1.3.8.0
+          history: 2w
+          trends: '0'
+          units: B
+          description: 'Total cumulative number of Read I/O bytes (sequential and random).'
+          tags:
+            - tag: Application
+              value: 'Nimble OS'
+        - uuid: c4a5510852cb4da492719eb8e0da5f19
+          name: 'Nimble-OS::ioSeqReadBytes'
+          type: SNMP_AGENT
+          snmp_oid: .1.3.6.1.4.1.37447.1.3.9.0
+          key: .1.3.6.1.4.1.37447.1.3.9.0
+          history: 2w
+          trends: '0'
+          units: B
+          description: 'Total cumulative number of Sequential Read I/O bytes.'
+          tags:
+            - tag: Application
+              value: 'Nimble OS'
+        - uuid: 2351c4d411424eae9fb03bbc42c06500
+          name: 'Nimble-OS::ioWriteBytes'
+          type: SNMP_AGENT
+          snmp_oid: .1.3.6.1.4.1.37447.1.3.10.0
+          key: .1.3.6.1.4.1.37447.1.3.10.0
+          history: 2w
+          trends: '0'
+          units: B
+          description: 'Total cumulative number of Write I/O bytes (sequential and random).'
+          tags:
+            - tag: Application
+              value: 'Nimble OS'
+        - uuid: f5f9ded8ebec43efafd3cfd43f3946db
+          name: 'Nimble-OS::ioSeqWriteBytes'
+          type: SNMP_AGENT
+          snmp_oid: .1.3.6.1.4.1.37447.1.3.11.0
+          key: .1.3.6.1.4.1.37447.1.3.11.0
+          history: 2w
+          trends: '0'
+          units: B
+          description: 'Total cumulative number of Sequential Write I/O bytes.'
+          tags:
+            - tag: Application
+              value: 'Nimble OS'
+        - uuid: 1d66e656c4a7478b93e8264eb59c2425
+          name: 'Nimble-OS::diskVolBytesUsedLow'
+          type: SNMP_AGENT
+          snmp_oid: .1.3.6.1.4.1.37447.1.3.12.0
+          key: .1.3.6.1.4.1.37447.1.3.12.0
+          history: 2w
+          trends: '0'
+          units: B
+          description: 'Total number of bytes used on disk for volumes - low order bytes.'
+          tags:
+            - tag: Application
+              value: 'Nimble OS'
+        - uuid: f1d1faa3ca824b9ba4eb52340c12c50c
+          name: 'Nimble-OS::diskVolBytesUsedHigh'
+          type: SNMP_AGENT
+          snmp_oid: .1.3.6.1.4.1.37447.1.3.13.0
+          key: .1.3.6.1.4.1.37447.1.3.13.0
+          history: 2w
+          trends: '0'
+          units: B
+          description: 'Total number of bytes used on disk for volumes - high order bytes.'
+          tags:
+            - tag: Application
+              value: 'Nimble OS'
+        - uuid: e024111045d74b359950b3d2fb8adc98
+          name: 'Nimble-OS::diskSnapBytesUsedLow'
+          type: SNMP_AGENT
+          snmp_oid: .1.3.6.1.4.1.37447.1.3.14.0
+          key: .1.3.6.1.4.1.37447.1.3.14.0
+          history: 2w
+          trends: '0'
+          units: B
+          description: 'Total number of bytes used on disk for snapshots - low order bytes.'
+          tags:
+            - tag: Application
+              value: 'Nimble OS'
+        - uuid: 543ef43778ba483f804aeae2a8a89de6
+          name: 'Nimble-OS::diskSnapBytesUsedHigh'
+          type: SNMP_AGENT
+          snmp_oid: .1.3.6.1.4.1.37447.1.3.15.0
+          key: .1.3.6.1.4.1.37447.1.3.15.0
+          history: 2w
+          trends: '0'
+          units: B
+          description: 'Total number of bytes used on disk for snapshots - high order bytes.'
+          tags:
+            - tag: Application
+              value: 'Nimble OS'
+        - uuid: 9e626a7aa79147e8ab2c624070fc08a2
+          name: 'Nimble-OS::ioNonseqReadHits'
+          type: SNMP_AGENT
+          snmp_oid: .1.3.6.1.4.1.37447.1.3.16.0
+          key: .1.3.6.1.4.1.37447.1.3.16.0
+          history: 2w
+          trends: '0'
+          description: 'Total cumulative number of cache hits for Non-Sequential Read I/Os.'
+          tags:
+            - tag: Application
+              value: 'Nimble OS'
+        - uuid: ac718160a648402985c489d4dd6bbed0
+          name: 'Nimble-OS::ioNonseqReadHitsDelta'
+          type: DEPENDENT
+          key: nimble.io.NonSeq.readHits.delta
+          trends: '0'
+          description: 'Cache-hit count for non-sequential reads since last poll.'
+          preprocessing:
+            - type: SIMPLE_CHANGE
+          master_item:
+            key: .1.3.6.1.4.1.37447.1.3.16.0
+          tags:
+            - tag: Application
+              value: 'Nimble OS'
+        - uuid: 91611e458a0c4fa795cc251b844d81c8
+          name: 'Nimble-OS::ioReadsDelta'
+          type: DEPENDENT
+          key: nimble.reads.delta
+          trends: '0'
+          description: 'Read I/O operations completed since previous check.'
+          preprocessing:
+            - type: SIMPLE_CHANGE
+          master_item:
+            key: .1.3.6.1.4.1.37447.1.3.2.0
+          tags:
+            - tag: Application
+              value: 'Nimble OS'
+        - uuid: e831c98d52fe4ce3af0be0077b1b1f89
+          name: 'Nimble-OS::ioReadBytesDelta'
+          type: DEPENDENT
+          key: nimble.read_bytes.delta
+          trends: '0'
+          description: 'Number of Read I/O bytes (sequential and random).'
+          preprocessing:
+            - type: SIMPLE_CHANGE
+          master_item:
+            key: .1.3.6.1.4.1.37447.1.3.8.0
+          tags:
+            - tag: Application
+              value: 'Nimble OS'
+        - uuid: 216f3001c39541548a13d90f5ff29cbe
+          name: 'Nimble-OS::ioReadTimeMicrosecDelta'
+          type: DEPENDENT
+          key: nimble.read_latency.delta
+          trends: '0'
+          units: ms
+          description: 'Per-interval increase in total system + disk latency for Read I/Os, converted to milliseconds.'
+          preprocessing:
+            - type: MULTIPLIER
+              parameters:
+                - '0.001'
+            - type: SIMPLE_CHANGE
+          master_item:
+            key: .1.3.6.1.4.1.37447.1.3.6.0
+          tags:
+            - tag: Application
+              value: 'Nimble OS'
+        - uuid: 142c2d27cb2c42bebc6286d97ed4c503
+          name: 'Nimble-OS::ioSeqReadsDelta'
+          type: DEPENDENT
+          key: nimble.seq_reads.delta
+          trends: '0'
+          description: 'Sequential read operations completed since last poll.'
+          preprocessing:
+            - type: SIMPLE_CHANGE
+          master_item:
+            key: .1.3.6.1.4.1.37447.1.3.3.0
+          tags:
+            - tag: Application
+              value: 'Nimble OS'
+        - uuid: 37df990a31b349c7bf7c9d7faa43dea8
+          name: 'Nimble-OS::ioSeqReadBytesDelta'
+          type: DEPENDENT
+          key: nimble.seq_read_bytes.delta
+          trends: '0'
+          units: B
+          description: 'Bytes read by sequential reads during the last polling interval.'
+          preprocessing:
+            - type: SIMPLE_CHANGE
+          master_item:
+            key: .1.3.6.1.4.1.37447.1.3.9.0
+          tags:
+            - tag: Application
+              value: 'Nimble OS'
+        - uuid: 0debaae18bb74312b951b5bf5c9b87d9
+          name: 'Nimble-OS::ioSeqWritesDelta'
+          type: DEPENDENT
+          key: nimble.seq_write.delta
+          trends: '0'
+          description: 'Sequential write operations completed since last check.'
+          preprocessing:
+            - type: SIMPLE_CHANGE
+          master_item:
+            key: .1.3.6.1.4.1.37447.1.3.5.0
+          tags:
+            - tag: Application
+              value: 'Nimble OS'
+        - uuid: 1644cf4b3e5a4a33bb980d6421a5bbd3
+          name: 'Nimble-OS::ioSeqWriteBytesDelta'
+          type: DEPENDENT
+          key: nimble.seq_write_bytes.delta
+          trends: '0'
+          description: 'Bytes written by sequential writes during the last polling interval.'
+          preprocessing:
+            - type: SIMPLE_CHANGE
+          master_item:
+            key: .1.3.6.1.4.1.37447.1.3.11.0
+          tags:
+            - tag: Application
+              value: 'Nimble OS'
+        - uuid: 6f9f029a057548939599e7ccaebeda80
+          name: 'Nimble-OS::ioWritesDelta'
+          type: DEPENDENT
+          key: nimble.writes.delta
+          trends: '0'
+          description: 'Number of write I/O operations completed since the previous check.'
+          preprocessing:
+            - type: SIMPLE_CHANGE
+          master_item:
+            key: .1.3.6.1.4.1.37447.1.3.4.0
+          tags:
+            - tag: Application
+              value: 'Nimble OS'
+        - uuid: 550ee63bdb114f8aa9f1e9089ae84bd6
+          name: 'Nimble-OS::ioWriteBytesDelta'
+          type: DEPENDENT
+          key: nimble.write_bytes.delta
+          trends: '0'
+          units: B
+          description: 'Bytes written to disk during the last polling interval.'
+          preprocessing:
+            - type: SIMPLE_CHANGE
+          master_item:
+            key: .1.3.6.1.4.1.37447.1.3.10.0
+          tags:
+            - tag: Application
+              value: 'Nimble OS'
+        - uuid: 4e86d9faf15d47d098367185fffbcb30
+          name: 'Nimble-OS::ioWriteTimeMicrosecDelta'
+          type: DEPENDENT
+          key: nimble.write_latency.delta
+          trends: '0'
+          units: ms
+          description: 'Per-interval increase in cumulative writes I/O latency, expressed in ms.'
+          preprocessing:
+            - type: MULTIPLIER
+              parameters:
+                - '0.001'
+            - type: SIMPLE_CHANGE
+          master_item:
+            key: .1.3.6.1.4.1.37447.1.3.7.0
+          tags:
+            - tag: Application
+              value: 'Nimble OS'
+      discovery_rules:
+        - uuid: a9b613800fb0435cb49630460168995b
+          name: 'Nimble-OS::volTable'
+          type: SNMP_AGENT
+          snmp_oid: 'discovery[{#VOLID},.1.3.6.1.4.1.37447.1.2.1.2,{#VOLNAME},.1.3.6.1.4.1.37447.1.2.1.3,{#VOLSIZELOW},.1.3.6.1.4.1.37447.1.2.1.4,{#VOLSIZEHIGH},.1.3.6.1.4.1.37447.1.2.1.5,{#VOLUSAGELOW},.1.3.6.1.4.1.37447.1.2.1.6,{#VOLUSAGEHIGH},.1.3.6.1.4.1.37447.1.2.1.7,{#VOLRESERVELOW},.1.3.6.1.4.1.37447.1.2.1.8,{#VOLRESERVEHIGH},.1.3.6.1.4.1.37447.1.2.1.9,{#VOLONLINE},.1.3.6.1.4.1.37447.1.2.1.10,{#VOLNUMCONNECTIONS},.1.3.6.1.4.1.37447.1.2.1.11,{#VOLSTATTIMEEPOCHSECONDS},.1.3.6.1.4.1.37447.1.2.1.12]'
+          key: .1.3.6.1.4.1.37447.1.2
+          delay: '3600'
+          lifetime: 30d
+          enabled_lifetime_type: DISABLE_NEVER
+          description: 'Volume information table.'
+          item_prototypes:
+            - uuid: a75f535f2ee04a6cb360ee09b2748b59
+              name: 'Nimble-OS::volID[{#SNMPINDEX}]'
+              type: SNMP_AGENT
+              snmp_oid: '.1.3.6.1.4.1.37447.1.2.1.2.{#SNMPINDEX}'
+              key: '.1.3.6.1.4.1.37447.1.2.1.2.[{#SNMPINDEX}]'
+              history: 2w
+              trends: '0'
+              description: 'Volume ID.'
+              tags:
+                - tag: Application
+                  value: 'Nimble OS'
+            - uuid: acf8f34817eb497e8b27813b555615d1
+              name: 'Nimble-OS::volName[{#SNMPINDEX}]'
+              type: SNMP_AGENT
+              snmp_oid: '.1.3.6.1.4.1.37447.1.2.1.3.{#SNMPINDEX}'
+              key: '.1.3.6.1.4.1.37447.1.2.1.3.[{#SNMPINDEX}]'
+              history: 2w
+              value_type: TEXT
+              description: 'Volume Name.'
+              tags:
+                - tag: Application
+                  value: 'Nimble OS'
+            - uuid: ab57e6cd39c14b1a82ad03449777f2e1
+              name: 'Nimble-OS::volSizeLow[{#SNMPINDEX}]'
+              type: SNMP_AGENT
+              snmp_oid: '.1.3.6.1.4.1.37447.1.2.1.4.{#SNMPINDEX}'
+              key: '.1.3.6.1.4.1.37447.1.2.1.4.[{#SNMPINDEX}]'
+              history: 2w
+              trends: '0'
+              units: B
+              description: 'Maximum defined size of a volume in bytes - low order bytes.'
+              tags:
+                - tag: Application
+                  value: 'Nimble OS'
+            - uuid: 6e04631ec2cd4f869c9db2a7d0ed002b
+              name: 'Nimble-OS::volSizeHigh[{#SNMPINDEX}]'
+              type: SNMP_AGENT
+              snmp_oid: '.1.3.6.1.4.1.37447.1.2.1.5.{#SNMPINDEX}'
+              key: '.1.3.6.1.4.1.37447.1.2.1.5.[{#SNMPINDEX}]'
+              history: 2w
+              trends: '0'
+              units: B
+              description: 'Maximum defined size of a volume in bytes - high order bytes.'
+              tags:
+                - tag: Application
+                  value: 'Nimble OS'
+            - uuid: b8e0adad6a68480e9a54fc6c266cf787
+              name: 'Nimble-OS::volUsageLow[{#SNMPINDEX}]'
+              type: SNMP_AGENT
+              snmp_oid: '.1.3.6.1.4.1.37447.1.2.1.6.{#SNMPINDEX}'
+              key: '.1.3.6.1.4.1.37447.1.2.1.6.[{#SNMPINDEX}]'
+              history: 2w
+              trends: '0'
+              units: B
+              description: 'Current number of bytes a volume is using - low order bytes.'
+              tags:
+                - tag: Application
+                  value: 'Nimble OS'
+            - uuid: e2bd9945deb34ee69c281dcc2a76a3d9
+              name: 'Nimble-OS::volUsageHigh[{#SNMPINDEX}]'
+              type: SNMP_AGENT
+              snmp_oid: '.1.3.6.1.4.1.37447.1.2.1.7.{#SNMPINDEX}'
+              key: '.1.3.6.1.4.1.37447.1.2.1.7.[{#SNMPINDEX}]'
+              history: 2w
+              trends: '0'
+              units: B
+              description: 'Current number of bytes a volume is using - high order bytes.'
+              tags:
+                - tag: Application
+                  value: 'Nimble OS'
+            - uuid: 1a05c86a222f46d6800df6b14af75a6a
+              name: 'Nimble-OS::volReserveLow[{#SNMPINDEX}]'
+              type: SNMP_AGENT
+              snmp_oid: '.1.3.6.1.4.1.37447.1.2.1.8.{#SNMPINDEX}'
+              key: '.1.3.6.1.4.1.37447.1.2.1.8.[{#SNMPINDEX}]'
+              history: 2w
+              trends: '0'
+              units: B
+              description: 'Number of bytes reserved for a volume - low order bytes.'
+              tags:
+                - tag: Application
+                  value: 'Nimble OS'
+            - uuid: 4fb41824305e424bb471da9473d2baec
+              name: 'Nimble-OS::volReserveHigh[{#SNMPINDEX}]'
+              type: SNMP_AGENT
+              snmp_oid: '.1.3.6.1.4.1.37447.1.2.1.9.{#SNMPINDEX}'
+              key: '.1.3.6.1.4.1.37447.1.2.1.9.[{#SNMPINDEX}]'
+              history: 2w
+              trends: '0'
+              units: B
+              description: 'Number of bytes reserved for a volume - high order bytes.'
+              tags:
+                - tag: Application
+                  value: 'Nimble OS'
+            - uuid: 9e68c0df6c3245a7a9e5aee12c4b9875
+              name: 'Nimble-OS::volOnline[{#SNMPINDEX}]'
+              type: SNMP_AGENT
+              snmp_oid: '.1.3.6.1.4.1.37447.1.2.1.10.{#SNMPINDEX}'
+              key: '.1.3.6.1.4.1.37447.1.2.1.10.[{#SNMPINDEX}]'
+              history: 2w
+              trends: '0'
+              description: 'Volume Online (true or false).'
+              valuemap:
+                name: 'Nimble-OS::volOnline'
+              tags:
+                - tag: Application
+                  value: 'Nimble OS'
+            - uuid: aa14fd14fa5e4e81afeca9a54c2c4c1d
+              name: 'Nimble-OS::volNumConnections[{#SNMPINDEX}]'
+              type: SNMP_AGENT
+              snmp_oid: '.1.3.6.1.4.1.37447.1.2.1.11.{#SNMPINDEX}'
+              key: '.1.3.6.1.4.1.37447.1.2.1.11.[{#SNMPINDEX}]'
+              history: 2w
+              trends: '0'
+              description: 'Number of iSCSI connections to the volume.'
+              tags:
+                - tag: Application
+                  value: 'Nimble OS'
+            - uuid: 41cf08abb9f54c56a9679cf584c4e405
+              name: 'Nimble-OS::volStatTimeEpochSeconds[{#SNMPINDEX}]'
+              type: SNMP_AGENT
+              snmp_oid: '.1.3.6.1.4.1.37447.1.2.1.12.{#SNMPINDEX}'
+              key: '.1.3.6.1.4.1.37447.1.2.1.12.[{#SNMPINDEX}]'
+              history: 2w
+              units: unixtime
+              description: 'Time at which the sample was taken, measured in seconds since UNIX epoch.'
+              tags:
+                - tag: Application
+                  value: 'Nimble OS'
+            - uuid: 3eb16a72d27741ce9ae915deec5f3133
+              name: 'Nimble-OS::volIoReads[{#SNMPINDEX}]'
+              type: SNMP_AGENT
+              snmp_oid: '.1.3.6.1.4.1.37447.1.2.1.13.{#SNMPINDEX}'
+              key: '.1.3.6.1.4.1.37447.1.2.1.13.[{#SNMPINDEX}]'
+              history: 2w
+              trends: '0'
+              description: 'Total cumulative number of Read I/Os (sequential and random).'
+              tags:
+                - tag: Application
+                  value: 'Nimble OS'
+            - uuid: 9957a27e857e48588a3aff460f3c3c2a
+              name: 'Nimble-OS::volIoReadTimeMicrosec[{#SNMPINDEX}]'
+              type: SNMP_AGENT
+              snmp_oid: '.1.3.6.1.4.1.37447.1.2.1.14.{#SNMPINDEX}'
+              key: '.1.3.6.1.4.1.37447.1.2.1.14.[{#SNMPINDEX}]'
+              history: 2w
+              trends: '0'
+              units: ms
+              description: 'Total cumulative time for Read operation (sequential and random).'
+              preprocessing:
+                - type: MULTIPLIER
+                  parameters:
+                    - '0.001'
+                - type: SIMPLE_CHANGE
+              tags:
+                - tag: Application
+                  value: 'Nimble OS'
+            - uuid: a681f67fae74473d94b8a48fd716cc87
+              name: 'Nimble-OS::volIoReadBytes[{#SNMPINDEX}]'
+              type: SNMP_AGENT
+              snmp_oid: '.1.3.6.1.4.1.37447.1.2.1.15.{#SNMPINDEX}'
+              key: '.1.3.6.1.4.1.37447.1.2.1.15.[{#SNMPINDEX}]'
+              history: 2w
+              trends: '0'
+              units: B
+              description: 'Total cumulative number of Read I/O bytes (sequential and random).'
+              tags:
+                - tag: Application
+                  value: 'Nimble OS'
+            - uuid: efa037550902496c995ab5ddd27c0908
+              name: 'Nimble-OS::volIoSeqReads[{#SNMPINDEX}]'
+              type: SNMP_AGENT
+              snmp_oid: '.1.3.6.1.4.1.37447.1.2.1.16.{#SNMPINDEX}'
+              key: '.1.3.6.1.4.1.37447.1.2.1.16.[{#SNMPINDEX}]'
+              history: 2w
+              trends: '0'
+              description: 'Total Number of Sequential Read I/O operations.'
+              tags:
+                - tag: Application
+                  value: 'Nimble OS'
+            - uuid: f322715c64294d63996527813d5f5859
+              name: 'Nimble-OS::volIoSeqReadBytes[{#SNMPINDEX}]'
+              type: SNMP_AGENT
+              snmp_oid: '.1.3.6.1.4.1.37447.1.2.1.17.{#SNMPINDEX}'
+              key: '.1.3.6.1.4.1.37447.1.2.1.17.[{#SNMPINDEX}]'
+              history: 2w
+              trends: '0'
+              units: B
+              description: 'Total cumulative number of Sequential Read I/O bytes.'
+              tags:
+                - tag: Application
+                  value: 'Nimble OS'
+            - uuid: 04f31e9b0a434c80ad59f1272f1bda74
+              name: 'Nimble-OS::volIoNonseqReadTotalHits[{#SNMPINDEX}]'
+              type: SNMP_AGENT
+              snmp_oid: '.1.3.6.1.4.1.37447.1.2.1.18.{#SNMPINDEX}'
+              key: '.1.3.6.1.4.1.37447.1.2.1.18.[{#SNMPINDEX}]'
+              history: 2w
+              description: 'Total number of Nonsequential Read I/O hits (to Memory and SSD).'
+              tags:
+                - tag: Application
+                  value: 'Nimble OS'
+            - uuid: c30f6388046f41449842ca573fb28a2f
+              name: 'Nimble-OS::volIoNonseqReadMemHits[{#SNMPINDEX}]'
+              type: SNMP_AGENT
+              snmp_oid: '.1.3.6.1.4.1.37447.1.2.1.19.{#SNMPINDEX}'
+              key: '.1.3.6.1.4.1.37447.1.2.1.19.[{#SNMPINDEX}]'
+              history: 2w
+              trends: '0'
+              description: 'Total number of Nonsequential Read I/O hits to Memory.'
+              tags:
+                - tag: Application
+                  value: 'Nimble OS'
+            - uuid: eff76e80740846fba7459d040cce8d73
+              name: 'Nimble-OS::volIoNonseqReadSSDHits[{#SNMPINDEX}]'
+              type: SNMP_AGENT
+              snmp_oid: '.1.3.6.1.4.1.37447.1.2.1.20.{#SNMPINDEX}'
+              key: '.1.3.6.1.4.1.37447.1.2.1.20.[{#SNMPINDEX}]'
+              history: 2w
+              trends: '0'
+              description: 'Total number of Nonsequential Read I/O hits to SSD.'
+              tags:
+                - tag: Application
+                  value: 'Nimble OS'
+            - uuid: 44ce809f8ea540a29bdfa6e2d6f3c212
+              name: 'Nimble-OS::volIoReadLatency0uTo100u[{#SNMPINDEX}]'
+              type: SNMP_AGENT
+              snmp_oid: '.1.3.6.1.4.1.37447.1.2.1.21.{#SNMPINDEX}'
+              key: '.1.3.6.1.4.1.37447.1.2.1.21.[{#SNMPINDEX}]'
+              history: 2w
+              trends: '0'
+              description: 'Number of Read I/O operations with latency between 0 and 100 microseconds.'
+              tags:
+                - tag: Application
+                  value: 'Nimble OS'
+            - uuid: 0595148f41a046ef9f3ca40a88525b46
+              name: 'Nimble-OS::volIoReadLatency100uTo200u[{#SNMPINDEX}]'
+              type: SNMP_AGENT
+              snmp_oid: '.1.3.6.1.4.1.37447.1.2.1.22.{#SNMPINDEX}'
+              key: '.1.3.6.1.4.1.37447.1.2.1.22.[{#SNMPINDEX}]'
+              history: 2w
+              trends: '0'
+              description: 'Number of Read I/O operations with latency between 100 and 200 microseconds.'
+              tags:
+                - tag: Application
+                  value: 'Nimble OS'
+            - uuid: 184c0025750d4d35b5d62d4e44631455
+              name: 'Nimble-OS::volIoReadLatency200uTo500u[{#SNMPINDEX}]'
+              type: SNMP_AGENT
+              snmp_oid: '.1.3.6.1.4.1.37447.1.2.1.23.{#SNMPINDEX}'
+              key: '.1.3.6.1.4.1.37447.1.2.1.23.[{#SNMPINDEX}]'
+              history: 2w
+              trends: '0'
+              description: 'Number of Read I/O operations with latency between 200 and 500 microseconds.'
+              tags:
+                - tag: Application
+                  value: 'Nimble OS'
+            - uuid: c2946abd5cea443784c239b70645e3ca
+              name: 'Nimble-OS::volIoReadLatency500uTo1m[{#SNMPINDEX}]'
+              type: SNMP_AGENT
+              snmp_oid: '.1.3.6.1.4.1.37447.1.2.1.24.{#SNMPINDEX}'
+              key: '.1.3.6.1.4.1.37447.1.2.1.24.[{#SNMPINDEX}]'
+              history: 2w
+              trends: '0'
+              description: 'Number of Read I/O operations with latency between 1/2 and 1 milliseconds.'
+              tags:
+                - tag: Application
+                  value: 'Nimble OS'
+            - uuid: f3d1c4f3b7fa4bc6ba3f3bdcf5271118
+              name: 'Nimble-OS::volIoReadLatency1mTo2m[{#SNMPINDEX}]'
+              type: SNMP_AGENT
+              snmp_oid: '.1.3.6.1.4.1.37447.1.2.1.25.{#SNMPINDEX}'
+              key: '.1.3.6.1.4.1.37447.1.2.1.25.[{#SNMPINDEX}]'
+              history: 2w
+              trends: '0'
+              description: 'Number of Read I/O operations with latency between 1 and 2 milliseconds.'
+              tags:
+                - tag: Application
+                  value: 'Nimble OS'
+            - uuid: a17a78edaf8e4434bd76c1029099d99d
+              name: 'Nimble-OS::volIoReadLatency2mTo5m[{#SNMPINDEX}]'
+              type: SNMP_AGENT
+              snmp_oid: '.1.3.6.1.4.1.37447.1.2.1.26.{#SNMPINDEX}'
+              key: '.1.3.6.1.4.1.37447.1.2.1.26.[{#SNMPINDEX}]'
+              history: 2w
+              trends: '0'
+              description: 'Number of Read I/O operations with latency between 2 and 5 milliseconds.'
+              tags:
+                - tag: Application
+                  value: 'Nimble OS'
+            - uuid: 197c95ba262f4829a12ac82b0d74b200
+              name: 'Nimble-OS::volIoReadLatency5mTo10m[{#SNMPINDEX}]'
+              type: SNMP_AGENT
+              snmp_oid: '.1.3.6.1.4.1.37447.1.2.1.27.{#SNMPINDEX}'
+              key: '.1.3.6.1.4.1.37447.1.2.1.27.[{#SNMPINDEX}]'
+              history: 2w
+              trends: '0'
+              description: 'Number of Read I/O operations with latency between 5 and 10 milliseconds.'
+              tags:
+                - tag: Application
+                  value: 'Nimble OS'
+            - uuid: 5776ada41ee44f89bdc936041df4fa5e
+              name: 'Nimble-OS::volIoReadLatency10mTo20m[{#SNMPINDEX}]'
+              type: SNMP_AGENT
+              snmp_oid: '.1.3.6.1.4.1.37447.1.2.1.28.{#SNMPINDEX}'
+              key: '.1.3.6.1.4.1.37447.1.2.1.28.[{#SNMPINDEX}]'
+              history: 2w
+              trends: '0'
+              description: 'Number of Read I/O operations with latency between 10 and 20 milliseconds.'
+              tags:
+                - tag: Application
+                  value: 'Nimble OS'
+            - uuid: 8ab9839beb374963a787a386355e62ef
+              name: 'Nimble-OS::volIoReadLatency20mTo50m[{#SNMPINDEX}]'
+              type: SNMP_AGENT
+              snmp_oid: '.1.3.6.1.4.1.37447.1.2.1.29.{#SNMPINDEX}'
+              key: '.1.3.6.1.4.1.37447.1.2.1.29.[{#SNMPINDEX}]'
+              history: 2w
+              trends: '0'
+              description: 'Number of Read I/O operations with latency between 20 and 50 milliseconds.'
+              tags:
+                - tag: Application
+                  value: 'Nimble OS'
+            - uuid: 377346e621854ceb979ae87bbb54bc01
+              name: 'Nimble-OS::volIoReadLatency50mTo100m[{#SNMPINDEX}]'
+              type: SNMP_AGENT
+              snmp_oid: '.1.3.6.1.4.1.37447.1.2.1.30.{#SNMPINDEX}'
+              key: '.1.3.6.1.4.1.37447.1.2.1.30.[{#SNMPINDEX}]'
+              history: 2w
+              trends: '0'
+              description: 'Number of Read I/O operations with latency between 50 and 100 milliseconds.'
+              tags:
+                - tag: Application
+                  value: 'Nimble OS'
+            - uuid: 909932ad797d47828f667475235a16a7
+              name: 'Nimble-OS::volIoReadLatency100mTo200m[{#SNMPINDEX}]'
+              type: SNMP_AGENT
+              snmp_oid: '.1.3.6.1.4.1.37447.1.2.1.31.{#SNMPINDEX}'
+              key: '.1.3.6.1.4.1.37447.1.2.1.31.[{#SNMPINDEX}]'
+              history: 2w
+              trends: '0'
+              description: 'Number of Read I/O operations with latency between 100 and 200 milliseconds.'
+              tags:
+                - tag: Application
+                  value: 'Nimble OS'
+            - uuid: c1d0af8d0ff849f785a36bb325161851
+              name: 'Nimble-OS::volIoReadLatency200mTo500m[{#SNMPINDEX}]'
+              type: SNMP_AGENT
+              snmp_oid: '.1.3.6.1.4.1.37447.1.2.1.32.{#SNMPINDEX}'
+              key: '.1.3.6.1.4.1.37447.1.2.1.32.[{#SNMPINDEX}]'
+              history: 2w
+              trends: '0'
+              description: 'Number of Read I/O operations with latency between 200 and 500 milliseconds.'
+              tags:
+                - tag: Application
+                  value: 'Nimble OS'
+            - uuid: d0c488891ef541d8b8badc4565c33f0e
+              name: 'Nimble-OS::volIoReadLatency500mTomax[{#SNMPINDEX}]'
+              type: SNMP_AGENT
+              snmp_oid: '.1.3.6.1.4.1.37447.1.2.1.33.{#SNMPINDEX}'
+              key: '.1.3.6.1.4.1.37447.1.2.1.33.[{#SNMPINDEX}]'
+              history: 2w
+              trends: '0'
+              description: 'Number of Read I/O operations with latency above 500 milliseconds.'
+              tags:
+                - tag: Application
+                  value: 'Nimble OS'
+            - uuid: b884f037aaa144a9b40084321aa618cb
+              name: 'Nimble-OS::volIoWrites[{#SNMPINDEX}]'
+              type: SNMP_AGENT
+              snmp_oid: '.1.3.6.1.4.1.37447.1.2.1.34.{#SNMPINDEX}'
+              key: '.1.3.6.1.4.1.37447.1.2.1.34.[{#SNMPINDEX}]'
+              history: 2w
+              description: 'Total cumulative number of Write I/Os.'
+              tags:
+                - tag: Application
+                  value: 'Nimble OS'
+            - uuid: e959f7cc290f4b6eba18451a2b9c18bb
+              name: 'Nimble-OS::volIoWriteTimeMicrosec[{#SNMPINDEX}]'
+              type: SNMP_AGENT
+              snmp_oid: '.1.3.6.1.4.1.37447.1.2.1.35.{#SNMPINDEX}'
+              key: '.1.3.6.1.4.1.37447.1.2.1.35.[{#SNMPINDEX}]'
+              history: 2w
+              units: ms
+              description: 'Total cumulative time for Write operation (sequential and random).'
+              tags:
+                - tag: Application
+                  value: 'Nimble OS'
+            - uuid: cb4ded6313264ea3933613a6a59328e0
+              name: 'Nimble-OS::volIoWriteBytes[{#SNMPINDEX}]'
+              type: SNMP_AGENT
+              snmp_oid: '.1.3.6.1.4.1.37447.1.2.1.36.{#SNMPINDEX}'
+              key: '.1.3.6.1.4.1.37447.1.2.1.36.[{#SNMPINDEX}]'
+              history: 2w
+              trends: '0'
+              units: B
+              description: 'Total cumulative number of Write I/O bytes (sequential and random).'
+              tags:
+                - tag: Application
+                  value: 'Nimble OS'
+            - uuid: 0ae806181724465bbe0424f6883f5ccb
+              name: 'Nimble-OS::volIoSeqWrites[{#SNMPINDEX}]'
+              type: SNMP_AGENT
+              snmp_oid: '.1.3.6.1.4.1.37447.1.2.1.37.{#SNMPINDEX}'
+              key: '.1.3.6.1.4.1.37447.1.2.1.37.[{#SNMPINDEX}]'
+              history: 2w
+              trends: '0'
+              description: 'Total Number of Sequential Write I/O operations.'
+              tags:
+                - tag: Application
+                  value: 'Nimble OS'
+            - uuid: 726e18eb993a48aab100c27135b66502
+              name: 'Nimble-OS::volIoSeqWriteBytes[{#SNMPINDEX}]'
+              type: SNMP_AGENT
+              snmp_oid: '.1.3.6.1.4.1.37447.1.2.1.38.{#SNMPINDEX}'
+              key: '.1.3.6.1.4.1.37447.1.2.1.38.[{#SNMPINDEX}]'
+              history: 2w
+              trends: '0'
+              units: B
+              description: 'Number of Sequential Write I/O bytes.'
+              tags:
+                - tag: Application
+                  value: 'Nimble OS'
+            - uuid: f3c81524a29945fb827d3047284428d5
+              name: 'Nimble-OS::volIoWriteLatency0uTo100u[{#SNMPINDEX}]'
+              type: SNMP_AGENT
+              snmp_oid: '.1.3.6.1.4.1.37447.1.2.1.39.{#SNMPINDEX}'
+              key: '.1.3.6.1.4.1.37447.1.2.1.39.[{#SNMPINDEX}]'
+              history: 2w
+              trends: '0'
+              description: 'Number of Write I/O operations with latency between 0 and 100 microseconds.'
+              tags:
+                - tag: Application
+                  value: 'Nimble OS'
+            - uuid: ec1fdf6ecd904a55bf47d808baece0fe
+              name: 'Nimble-OS::volIoWriteLatency100uTo200u[{#SNMPINDEX}]'
+              type: SNMP_AGENT
+              snmp_oid: '.1.3.6.1.4.1.37447.1.2.1.40.{#SNMPINDEX}'
+              key: '.1.3.6.1.4.1.37447.1.2.1.40.[{#SNMPINDEX}]'
+              history: 2w
+              trends: '0'
+              description: 'Number of Write I/O operations with latency between 100 and 200'
+              tags:
+                - tag: Application
+                  value: 'Nimble OS'
+            - uuid: cf4ac1bf942843cfacc571555f646937
+              name: 'Nimble-OS::volIoWriteLatency200uTo500u[{#SNMPINDEX}]'
+              type: SNMP_AGENT
+              snmp_oid: '.1.3.6.1.4.1.37447.1.2.1.41.{#SNMPINDEX}'
+              key: '.1.3.6.1.4.1.37447.1.2.1.41.[{#SNMPINDEX}]'
+              history: 2w
+              trends: '0'
+              description: 'Number of Write I/O operations with latency between 200 and 500 microseconds.'
+              tags:
+                - tag: Application
+                  value: 'Nimble OS'
+            - uuid: c1a01cb349ff454792f0984dbd161494
+              name: 'Nimble-OS::volIoWriteLatency500uTo1m[{#SNMPINDEX}]'
+              type: SNMP_AGENT
+              snmp_oid: '.1.3.6.1.4.1.37447.1.2.1.42.{#SNMPINDEX}'
+              key: '.1.3.6.1.4.1.37447.1.2.1.42.[{#SNMPINDEX}]'
+              history: 2w
+              description: 'Number of Write I/O operations with latency between 1/2 and 1 milliseconds.'
+              tags:
+                - tag: Application
+                  value: 'Nimble OS'
+            - uuid: 25323e43edf54d308b2e3f2c4f77d343
+              name: 'Nimble-OS::volIoWriteLatency1mTo2m[{#SNMPINDEX}]'
+              type: SNMP_AGENT
+              snmp_oid: '.1.3.6.1.4.1.37447.1.2.1.43.{#SNMPINDEX}'
+              key: '.1.3.6.1.4.1.37447.1.2.1.43.[{#SNMPINDEX}]'
+              history: 2w
+              trends: '0'
+              description: 'Number of Write I/O operations with latency between 1 and 2 milliseconds.'
+              tags:
+                - tag: Application
+                  value: 'Nimble OS'
+            - uuid: 288eac5a74454570b740c20f63738103
+              name: 'Nimble-OS::volIoWriteLatency2mTo5m[{#SNMPINDEX}]'
+              type: SNMP_AGENT
+              snmp_oid: '.1.3.6.1.4.1.37447.1.2.1.44.{#SNMPINDEX}'
+              key: '.1.3.6.1.4.1.37447.1.2.1.44.[{#SNMPINDEX}]'
+              history: 2w
+              trends: '0'
+              description: 'Number of Write I/O operations with latency between 2 and 5 milliseconds.'
+              tags:
+                - tag: Application
+                  value: 'Nimble OS'
+            - uuid: 3993c03618e2429290e8e96b619713e0
+              name: 'Nimble-OS::volIoWriteLatency5mTo10m[{#SNMPINDEX}]'
+              type: SNMP_AGENT
+              snmp_oid: '.1.3.6.1.4.1.37447.1.2.1.45.{#SNMPINDEX}'
+              key: '.1.3.6.1.4.1.37447.1.2.1.45.[{#SNMPINDEX}]'
+              history: 2w
+              trends: '0'
+              description: 'Number of Write I/O operations with latency between 5 and 10 milliseconds.'
+              tags:
+                - tag: Application
+                  value: 'Nimble OS'
+            - uuid: 197921ca1b2441d08856f3d317084138
+              name: 'Nimble-OS::volIoWriteLatency10mTo20m[{#SNMPINDEX}]'
+              type: SNMP_AGENT
+              snmp_oid: '.1.3.6.1.4.1.37447.1.2.1.46.{#SNMPINDEX}'
+              key: '.1.3.6.1.4.1.37447.1.2.1.46.[{#SNMPINDEX}]'
+              history: 2w
+              trends: '0'
+              description: 'Number of Write I/O operations with latency between 10 and 20 milliseconds.'
+              tags:
+                - tag: Application
+                  value: 'Nimble OS'
+            - uuid: 22c96dc33f074c27adb0f528e1537307
+              name: 'Nimble-OS::volIoWriteLatency20mTo50m[{#SNMPINDEX}]'
+              type: SNMP_AGENT
+              snmp_oid: '.1.3.6.1.4.1.37447.1.2.1.47.{#SNMPINDEX}'
+              key: '.1.3.6.1.4.1.37447.1.2.1.47.[{#SNMPINDEX}]'
+              history: 2w
+              trends: '0'
+              description: 'Number of Write I/O operations with latency between 20 and 50 milliseconds.'
+              tags:
+                - tag: Application
+                  value: 'Nimble OS'
+            - uuid: 5ded4f137ced4e98b48f44ad3a4573d4
+              name: 'Nimble-OS::volIoWriteLatency50mTo100m[{#SNMPINDEX}]'
+              type: SNMP_AGENT
+              snmp_oid: '.1.3.6.1.4.1.37447.1.2.1.48.{#SNMPINDEX}'
+              key: '.1.3.6.1.4.1.37447.1.2.1.48.[{#SNMPINDEX}]'
+              history: 2w
+              trends: '0'
+              description: 'Number of Write I/O operations with latency between 50 and 100 milliseconds.'
+              tags:
+                - tag: Application
+                  value: 'Nimble OS'
+            - uuid: 6fdce410a8c143b68bc55009044271d3
+              name: 'Nimble-OS::volIoWriteLatency100mTo200m[{#SNMPINDEX}]'
+              type: SNMP_AGENT
+              snmp_oid: '.1.3.6.1.4.1.37447.1.2.1.49.{#SNMPINDEX}'
+              key: '.1.3.6.1.4.1.37447.1.2.1.49.[{#SNMPINDEX}]'
+              history: 2w
+              trends: '0'
+              description: 'Number of Write I/O operations with latency between 100 and 200 milliseconds.'
+              tags:
+                - tag: Application
+                  value: 'Nimble OS'
+            - uuid: 1db071e1f47c42fb8917b3e0b08d8abb
+              name: 'Nimble-OS::volIoWriteLatency200mTo500m[{#SNMPINDEX}]'
+              type: SNMP_AGENT
+              snmp_oid: '.1.3.6.1.4.1.37447.1.2.1.50.{#SNMPINDEX}'
+              key: '.1.3.6.1.4.1.37447.1.2.1.50.[{#SNMPINDEX}]'
+              history: 2w
+              trends: '0'
+              description: 'Number of Write I/O operations with latency between 200 and 500 milliseconds.'
+              tags:
+                - tag: Application
+                  value: 'Nimble OS'
+            - uuid: 0e5ef32270814e3d91aac2b01faac6be
+              name: 'Nimble-OS::volIoWriteLatency500mTomax[{#SNMPINDEX}]'
+              type: SNMP_AGENT
+              snmp_oid: '.1.3.6.1.4.1.37447.1.2.1.51.{#SNMPINDEX}'
+              key: '.1.3.6.1.4.1.37447.1.2.1.51.[{#SNMPINDEX}]'
+              history: 2w
+              trends: '0'
+              description: 'Number of Write I/O operations with latency above 500 milliseconds.'
+              tags:
+                - tag: Application
+                  value: 'Nimble OS'
+            - uuid: a17c6405c9a749d3b2838542e89f3ebb
+              name: 'Nimble-OS::volDiskVolBytesUsedLow[{#SNMPINDEX}]'
+              type: SNMP_AGENT
+              snmp_oid: '.1.3.6.1.4.1.37447.1.2.1.52.{#SNMPINDEX}'
+              key: '.1.3.6.1.4.1.37447.1.2.1.52.[{#SNMPINDEX}]'
+              history: 2w
+              trends: '0'
+              units: B
+              description: 'Total number of bytes used on disk for volumes - low order bytes.'
+              tags:
+                - tag: Application
+                  value: 'Nimble OS'
+            - uuid: 6c1a0136562742519c086630e0d281f3
+              name: 'Nimble-OS::volDiskVolBytesUsedHigh[{#SNMPINDEX}]'
+              type: SNMP_AGENT
+              snmp_oid: '.1.3.6.1.4.1.37447.1.2.1.53.{#SNMPINDEX}'
+              key: '.1.3.6.1.4.1.37447.1.2.1.53.[{#SNMPINDEX}]'
+              history: 2w
+              trends: '0'
+              units: B
+              description: 'Total number of bytes used on disk for volumes - high order bytes.'
+              tags:
+                - tag: Application
+                  value: 'Nimble OS'
+            - uuid: 766124d2feba490ab901c08d098fb8de
+              name: 'Nimble-OS::volDiskSnapBytesUsedLow[{#SNMPINDEX}]'
+              type: SNMP_AGENT
+              snmp_oid: '.1.3.6.1.4.1.37447.1.2.1.54.{#SNMPINDEX}'
+              key: '.1.3.6.1.4.1.37447.1.2.1.54.[{#SNMPINDEX}]'
+              history: 2w
+              trends: '0'
+              units: B
+              description: 'Total number of bytes used on disk for snapshots - low order bytes.'
+              tags:
+                - tag: Application
+                  value: 'Nimble OS'
+            - uuid: 67f1ca591cfc486a8a7b0ab7a2c1255d
+              name: 'Nimble-OS::volDiskSnapBytesUsedHigh[{#SNMPINDEX}]'
+              type: SNMP_AGENT
+              snmp_oid: '.1.3.6.1.4.1.37447.1.2.1.55.{#SNMPINDEX}'
+              key: '.1.3.6.1.4.1.37447.1.2.1.55.[{#SNMPINDEX}]'
+              history: 2w
+              trends: '0'
+              units: B
+              description: 'Total number of bytes used on disk for snapshots - high order bytes.'
+              tags:
+                - tag: Application
+                  value: 'Nimble OS'
+            - uuid: 085d14b29d844c1ab604ffbad5b875ec
+              name: 'Nimble-OS::volIoNonseqReadMemHits.Delta[{#SNMPINDEX}]'
+              type: DEPENDENT
+              key: 'volIoNonseqReadMemHits.Delta.[{#SNMPINDEX}]'
+              trends: '0'
+              description: 'Per-interval increase in Non-sequential Read I/O hits to Memory.'
+              preprocessing:
+                - type: SIMPLE_CHANGE
+              master_item:
+                key: '.1.3.6.1.4.1.37447.1.2.1.19.[{#SNMPINDEX}]'
+              tags:
+                - tag: Application
+                  value: 'Nimble OS'
+            - uuid: 7dc1b1c5d6f74168a96a68c67a33efb6
+              name: 'Nimble-OS::volIoNonseqReadSSDHits.Delta[{#SNMPINDEX}]'
+              type: DEPENDENT
+              key: 'volIoNonseqReadSSDHits.Delta[{#SNMPINDEX}]'
+              trends: '0'
+              description: 'Per-interval increase in non-sequential Read I/O hits to SSD.'
+              preprocessing:
+                - type: SIMPLE_CHANGE
+              master_item:
+                key: '.1.3.6.1.4.1.37447.1.2.1.20.[{#SNMPINDEX}]'
+              tags:
+                - tag: Application
+                  value: 'Nimble OS'
+            - uuid: a60986908b304aa0aa2f878478d2122c
+              name: 'Nimble-OS::volIoNonseqReadTotalHits.Delta[{#SNMPINDEX}]'
+              type: DEPENDENT
+              key: 'volIoNonseqReadTotalHits.Delta[{#SNMPINDEX}]'
+              trends: '0'
+              description: 'Per-interval increase in non-sequential Read I/O hits (to Memory and SSD).'
+              preprocessing:
+                - type: SIMPLE_CHANGE
+              master_item:
+                key: '.1.3.6.1.4.1.37447.1.2.1.18.[{#SNMPINDEX}]'
+              tags:
+                - tag: Application
+                  value: 'Nimble OS'
+            - uuid: ab48de3b341348db879ed759146368a9
+              name: 'Nimble-OS::volIoReadBytes.Delta[{#SNMPINDEX}]'
+              type: DEPENDENT
+              key: 'volIoReadBytes.Delta[{#SNMPINDEX}]'
+              trends: '0'
+              units: B
+              description: 'Per-interval increase in Read I/O bytes (sequential and random).'
+              preprocessing:
+                - type: SIMPLE_CHANGE
+              master_item:
+                key: '.1.3.6.1.4.1.37447.1.2.1.15.[{#SNMPINDEX}]'
+              tags:
+                - tag: Application
+                  value: 'Nimble OS'
+            - uuid: 76450d6e9cda423ebb1e869fce50132a
+              name: 'Nimble-OS::volIoReadLatency0uTo100u.Delta[{#SNMPINDEX}]'
+              type: DEPENDENT
+              key: 'volIoReadLatency0uTo100u.Delta[{#SNMPINDEX}]'
+              trends: '0'
+              description: 'Per-interval increase in the number of Read I/O operations with latency between 0 and 100 microseconds.'
+              preprocessing:
+                - type: SIMPLE_CHANGE
+              master_item:
+                key: '.1.3.6.1.4.1.37447.1.2.1.21.[{#SNMPINDEX}]'
+              tags:
+                - tag: Application
+                  value: 'Nimble OS'
+            - uuid: 992e99a564cf41c1a5aafdab98e229f5
+              name: 'Nimble-OS::volIoReadLatency1mTo2m.Delta[{#SNMPINDEX}]'
+              type: DEPENDENT
+              key: 'volIoReadLatency1mTo2m.Delta[{#SNMPINDEX}]'
+              trends: '0'
+              description: 'Per-interval increase in the number of Read I/O operations with latency between 1 and 2 milliseconds.'
+              preprocessing:
+                - type: SIMPLE_CHANGE
+              master_item:
+                key: '.1.3.6.1.4.1.37447.1.2.1.25.[{#SNMPINDEX}]'
+              tags:
+                - tag: Application
+                  value: 'Nimble OS'
+            - uuid: e50dc8bc48fb447eabda4b9985653ab4
+              name: 'Nimble-OS::volIoReadLatency2mTo5m.Delta[{#SNMPINDEX}]'
+              type: DEPENDENT
+              key: 'volIoReadLatency2mTo5m.Delta[{#SNMPINDEX}]'
+              trends: '0'
+              description: 'Per-interval increase in the number of Read I/O operations with latency between 2 and 5 milliseconds.'
+              preprocessing:
+                - type: SIMPLE_CHANGE
+              master_item:
+                key: '.1.3.6.1.4.1.37447.1.2.1.26.[{#SNMPINDEX}]'
+              tags:
+                - tag: Application
+                  value: 'Nimble OS'
+            - uuid: 7d2009905c724ef5b0a20290ad77f011
+              name: 'Nimble-OS::volIoReadLatency5mTo10m.Delta[{#SNMPINDEX}]'
+              type: DEPENDENT
+              key: 'volIoReadLatency5mTo10m.Delta[{#SNMPINDEX}]'
+              trends: '0'
+              description: 'Per-interval increase in the number of Read I/O operations with latency between 5 and 10 milliseconds.'
+              preprocessing:
+                - type: SIMPLE_CHANGE
+              master_item:
+                key: '.1.3.6.1.4.1.37447.1.2.1.27.[{#SNMPINDEX}]'
+              tags:
+                - tag: Application
+                  value: 'Nimble OS'
+            - uuid: 0d3e7eb151144c198d8fdcc88dbc622b
+              name: 'Nimble-OS::volIoReadLatency10mTo20m.Delta[{#SNMPINDEX}]'
+              type: DEPENDENT
+              key: 'volIoReadLatency10mTo20m.Delta[{#SNMPINDEX}]'
+              trends: '0'
+              description: 'Per-interval increase in the number of Read I/O operations with latency between 10 and 20 milliseconds.'
+              preprocessing:
+                - type: SIMPLE_CHANGE
+              master_item:
+                key: '.1.3.6.1.4.1.37447.1.2.1.28.[{#SNMPINDEX}]'
+              tags:
+                - tag: Application
+                  value: 'Nimble OS'
+            - uuid: 0de76796312245929d80e4df50d8f9ac
+              name: 'Nimble-OS::volIoReadLatency20mTo50m.Delta[{#SNMPINDEX}]'
+              type: DEPENDENT
+              key: 'volIoReadLatency20mTo50m.Delta[{#SNMPINDEX}]'
+              trends: '0'
+              description: 'Per-interval increase in the number of Read I/O operations with latency between 20 and 50 milliseconds.'
+              preprocessing:
+                - type: SIMPLE_CHANGE
+              master_item:
+                key: '.1.3.6.1.4.1.37447.1.2.1.29.[{#SNMPINDEX}]'
+              tags:
+                - tag: Application
+                  value: 'Nimble OS'
+            - uuid: 32955d02dd7d406296c63f5338673bf1
+              name: 'Nimble-OS::volIoReadLatency50mTo100m.Delta[{#SNMPINDEX}]'
+              type: DEPENDENT
+              key: 'volIoReadLatency50mTo100m.Delta[{#SNMPINDEX}]'
+              trends: '0'
+              description: 'Per-interval increase in the number of Read I/O operations with latency between 50 and 100 milliseconds.'
+              preprocessing:
+                - type: SIMPLE_CHANGE
+              master_item:
+                key: '.1.3.6.1.4.1.37447.1.2.1.30.[{#SNMPINDEX}]'
+              tags:
+                - tag: Application
+                  value: 'Nimble OS'
+            - uuid: c83dcbbb6e464cfdb020b8ac9b63fb7d
+              name: 'Nimble-OS::volIoReadLatency100mTo200m.Delta[{#SNMPINDEX}]'
+              type: DEPENDENT
+              key: 'volIoReadLatency100mTo200m.Delta[{#SNMPINDEX}]'
+              trends: '0'
+              description: 'Per-interval increase in the number of Read I/O operations with latency between 100 and 200 milliseconds.'
+              preprocessing:
+                - type: SIMPLE_CHANGE
+              master_item:
+                key: '.1.3.6.1.4.1.37447.1.2.1.31.[{#SNMPINDEX}]'
+              tags:
+                - tag: Application
+                  value: 'Nimble OS'
+            - uuid: 8325f375347b4e6f94979c225edfd02a
+              name: 'Nimble-OS::volIoReadLatency100uTo200u.Delta[{#SNMPINDEX}]'
+              type: DEPENDENT
+              key: 'volIoReadLatency100uTo200u.Delta[{#SNMPINDEX}]'
+              trends: '0'
+              description: 'Per-interval increase in the number of Read I/O operations with latency between 100 and 200 microseconds.'
+              preprocessing:
+                - type: SIMPLE_CHANGE
+              master_item:
+                key: '.1.3.6.1.4.1.37447.1.2.1.22.[{#SNMPINDEX}]'
+              tags:
+                - tag: Application
+                  value: 'Nimble OS'
+            - uuid: dc062e8d215645f3bdd7a5a9458898cc
+              name: 'Nimble-OS::volIoReadLatency200mTo500m.Delta[{#SNMPINDEX}]'
+              type: DEPENDENT
+              key: 'volIoReadLatency200mTo500m.Delta[{#SNMPINDEX}]'
+              trends: '0'
+              description: 'Per-interval increase in the number of Read I/O operations with latency between 200 and 500 milliseconds.'
+              preprocessing:
+                - type: SIMPLE_CHANGE
+              master_item:
+                key: '.1.3.6.1.4.1.37447.1.2.1.32.[{#SNMPINDEX}]'
+              tags:
+                - tag: Application
+                  value: 'Nimble OS'
+            - uuid: e7ecc90739fd4a76ad6e7742b6fa7f2d
+              name: 'Nimble-OS::volIoReadLatency200uTo500u.Delta[{#SNMPINDEX}]'
+              type: DEPENDENT
+              key: 'volIoReadLatency200uTo500u.Delta[{#SNMPINDEX}]'
+              trends: '0'
+              preprocessing:
+                - type: SIMPLE_CHANGE
+              master_item:
+                key: '.1.3.6.1.4.1.37447.1.2.1.23.[{#SNMPINDEX}]'
+              tags:
+                - tag: Application
+                  value: 'Nimble OS'
+            - uuid: d5780d70b0ed414ab470e0578043d9ae
+              name: 'Nimble-OS::volIoReadLatency500mTomax.Delta[{#SNMPINDEX}]'
+              type: DEPENDENT
+              key: 'volIoReadLatency500mTomax.Delta[{#SNMPINDEX}]'
+              trends: '0'
+              description: 'Per-interval increase in the number of Read I/O operations with latency above 500 milliseconds.'
+              preprocessing:
+                - type: SIMPLE_CHANGE
+              master_item:
+                key: '.1.3.6.1.4.1.37447.1.2.1.33.[{#SNMPINDEX}]'
+              tags:
+                - tag: Application
+                  value: 'Nimble OS'
+            - uuid: 074e52bf04e44cc9bc8e29dae77a64aa
+              name: 'Nimble-OS::volIoReadLatency500uTo1m.Delta[{#SNMPINDEX}]'
+              type: DEPENDENT
+              key: 'volIoReadLatency500uTo1m.Delta[{#SNMPINDEX}]'
+              trends: '0'
+              description: 'Per-interval increase in the number of Read I/O operations with latency between 1/2 and 1 milliseconds.'
+              preprocessing:
+                - type: SIMPLE_CHANGE
+              master_item:
+                key: '.1.3.6.1.4.1.37447.1.2.1.24.[{#SNMPINDEX}]'
+              tags:
+                - tag: Application
+                  value: 'Nimble OS'
+            - uuid: fee8441649f94d2294b33fc9e6025501
+              name: 'Nimble-OS::volIoReads.Delta[{#SNMPINDEX}]'
+              type: DEPENDENT
+              key: 'volIoReads.Delta[{#SNMPINDEX}]'
+              trends: '0'
+              description: 'Per-interval increase in the number of Read I/Os (sequential and random).'
+              preprocessing:
+                - type: SIMPLE_CHANGE
+              master_item:
+                key: '.1.3.6.1.4.1.37447.1.2.1.13.[{#SNMPINDEX}]'
+              tags:
+                - tag: Application
+                  value: 'Nimble OS'
+            - uuid: 7da1df8e89904f3f8cbae2c69defb63f
+              name: 'Nimble-OS::volIoReadTimeMicrosec.Delta[{#SNMPINDEX}]'
+              type: DEPENDENT
+              key: 'volIoReadTimeMicrosec.Delta[{#SNMPINDEX}]'
+              trends: '0'
+              units: ms
+              description: 'Per-interval increase in the time for Read operations (sequential and random).'
+              preprocessing:
+                - type: MULTIPLIER
+                  parameters:
+                    - '0.001'
+                - type: SIMPLE_CHANGE
+              master_item:
+                key: '.1.3.6.1.4.1.37447.1.2.1.14.[{#SNMPINDEX}]'
+              tags:
+                - tag: Application
+                  value: 'Nimble OS'
+            - uuid: bdeefc8a6704428586b2bbd9dfc2d931
+              name: 'Nimble-OS::volIoSeqReadBytes.Delta[{#SNMPINDEX}]'
+              type: DEPENDENT
+              key: 'volIoSeqReadBytes.Delta[{#SNMPINDEX}]'
+              trends: '0'
+              units: B
+              description: 'Per-interval increase in the number of Sequential Read I/O bytes.'
+              preprocessing:
+                - type: SIMPLE_CHANGE
+              master_item:
+                key: '.1.3.6.1.4.1.37447.1.2.1.17.[{#SNMPINDEX}]'
+              tags:
+                - tag: Application
+                  value: 'Nimble OS'
+            - uuid: 489d6f99635d453e8f079fe73a9fe44a
+              name: 'Nimble-OS::volIoSeqReads.Delta[{#SNMPINDEX}]'
+              type: DEPENDENT
+              key: 'volIoSeqReads.Delta[{#SNMPINDEX}]'
+              trends: '0'
+              description: 'Per-interval increase in the number of Sequential Read I/O operations.'
+              preprocessing:
+                - type: SIMPLE_CHANGE
+              master_item:
+                key: '.1.3.6.1.4.1.37447.1.2.1.16.[{#SNMPINDEX}]'
+              tags:
+                - tag: Application
+                  value: 'Nimble OS'
+            - uuid: 2683c92ff0f2418fb126b2ee2ff5282e
+              name: 'Nimble-OS::volIoSeqWriteBytes.Delta[{#SNMPINDEX}]'
+              type: DEPENDENT
+              key: 'volIoSeqWriteBytes.Delta[{#SNMPINDEX}]'
+              trends: '0'
+              units: B
+              description: 'Per-interval increase in the number of Sequential Write I/O bytes.'
+              preprocessing:
+                - type: SIMPLE_CHANGE
+              master_item:
+                key: '.1.3.6.1.4.1.37447.1.2.1.38.[{#SNMPINDEX}]'
+              tags:
+                - tag: Application
+                  value: 'Nimble OS'
+            - uuid: aef9191b1ba24045852f62d2032b9862
+              name: 'Nimble-OS::volIoSeqWrites.Delta[{#SNMPINDEX}]'
+              type: DEPENDENT
+              key: 'volIoSeqWrites.Delta[{#SNMPINDEX}]'
+              trends: '0'
+              description: 'Per-interval increase in the number of Sequential Write I/O operations.'
+              preprocessing:
+                - type: SIMPLE_CHANGE
+              master_item:
+                key: '.1.3.6.1.4.1.37447.1.2.1.37.[{#SNMPINDEX}]'
+              tags:
+                - tag: Application
+                  value: 'Nimble OS'
+            - uuid: 455c18034791415cb92468540ae947e0
+              name: 'Nimble-OS::volIoWriteBytes.Delta[{#SNMPINDEX}]'
+              type: DEPENDENT
+              key: 'volIoWriteBytes.Delta[{#SNMPINDEX}]'
+              trends: '0'
+              units: B
+              description: 'Per-interval increase in the number of Write I/O bytes (sequential and random).'
+              preprocessing:
+                - type: SIMPLE_CHANGE
+              master_item:
+                key: '.1.3.6.1.4.1.37447.1.2.1.36.[{#SNMPINDEX}]'
+              tags:
+                - tag: Application
+                  value: 'Nimble OS'
+            - uuid: e1f34968070648ac93e2fa7301e0cee6
+              name: 'Nimble-OS::volIoWriteLatency0uTo100u.Delta[{#SNMPINDEX}]'
+              type: DEPENDENT
+              key: 'volIoWriteLatency0uTo100u.Delta[{#SNMPINDEX}]'
+              trends: '0'
+              description: 'Per-interval increase in the number of Write I/O operations with latency between 0 and 100 microseconds.'
+              preprocessing:
+                - type: SIMPLE_CHANGE
+              master_item:
+                key: '.1.3.6.1.4.1.37447.1.2.1.39.[{#SNMPINDEX}]'
+              tags:
+                - tag: Application
+                  value: 'Nimble OS'
+            - uuid: ef785b56678b4defb77e1401ac262eea
+              name: 'Nimble-OS::volIoWriteLatency1mTo2m.Delta[{#SNMPINDEX}]'
+              type: DEPENDENT
+              key: 'volIoWriteLatency1mTo2m.Delta[{#SNMPINDEX}]'
+              trends: '0'
+              description: 'Per-interval increase in the number of Write I/O operations with latency between 1 and 2 milliseconds.'
+              preprocessing:
+                - type: SIMPLE_CHANGE
+              master_item:
+                key: '.1.3.6.1.4.1.37447.1.2.1.43.[{#SNMPINDEX}]'
+              tags:
+                - tag: Application
+                  value: 'Nimble OS'
+            - uuid: 58ca102d25bc46cc9a970c87da9bf3e8
+              name: 'Nimble-OS::volIoWriteLatency2mTo5m.Delta[{#SNMPINDEX}]'
+              type: DEPENDENT
+              key: 'volIoWriteLatency2mTo5m.Delta[{#SNMPINDEX}]'
+              trends: '0'
+              description: 'Per-interval increase in the number of Write I/O operations with latency between 2 and 5 milliseconds.'
+              preprocessing:
+                - type: SIMPLE_CHANGE
+              master_item:
+                key: '.1.3.6.1.4.1.37447.1.2.1.44.[{#SNMPINDEX}]'
+              tags:
+                - tag: Application
+                  value: 'Nimble OS'
+            - uuid: 58c9b3bc7c5445dbac8b21ff3762383d
+              name: 'Nimble-OS::volIoWriteLatency5mTo10m.Delta[{#SNMPINDEX}]'
+              type: DEPENDENT
+              key: 'volIoWriteLatency5mTo10m.Delta[{#SNMPINDEX}]'
+              trends: '0'
+              description: 'Per-interval increase in the number of Write I/O operations with latency between 5 and 10 milliseconds.'
+              preprocessing:
+                - type: SIMPLE_CHANGE
+              master_item:
+                key: '.1.3.6.1.4.1.37447.1.2.1.45.[{#SNMPINDEX}]'
+              tags:
+                - tag: Application
+                  value: 'Nimble OS'
+            - uuid: aa810f99fd7c49bf968849fa3618b727
+              name: 'Nimble-OS::volIoWriteLatency10mTo20m.Delta[{#SNMPINDEX}]'
+              type: DEPENDENT
+              key: 'volIoWriteLatency10mTo20m.Delta[{#SNMPINDEX}]'
+              trends: '0'
+              description: 'Per-interval increase in the number of Write I/O operations with latency between 10 and 20 milliseconds.'
+              preprocessing:
+                - type: SIMPLE_CHANGE
+              master_item:
+                key: '.1.3.6.1.4.1.37447.1.2.1.46.[{#SNMPINDEX}]'
+              tags:
+                - tag: Application
+                  value: 'Nimble OS'
+            - uuid: 6796c045dcc54c76b560adeafb42adce
+              name: 'Nimble-OS::volIoWriteLatency20mTo50m.Delta[{#SNMPINDEX}]'
+              type: DEPENDENT
+              key: 'volIoWriteLatency20mTo50m.Delta[{#SNMPINDEX}]'
+              trends: '0'
+              description: 'Per-interval increase in the number of Write I/O operations with latency between 20 and 50 milliseconds.'
+              preprocessing:
+                - type: SIMPLE_CHANGE
+              master_item:
+                key: '.1.3.6.1.4.1.37447.1.2.1.47.[{#SNMPINDEX}]'
+              tags:
+                - tag: Application
+                  value: 'Nimble OS'
+            - uuid: 0b159441e6044fdea569d4741b82dcd8
+              name: 'Nimble-OS::volIoWriteLatency50mTo100m.Delta[{#SNMPINDEX}]'
+              type: DEPENDENT
+              key: 'volIoWriteLatency50mTo100m.Delta[{#SNMPINDEX}]'
+              trends: '0'
+              description: 'Per-interval increase in the number of Write I/O operations with latency between 50 and 100 milliseconds.'
+              preprocessing:
+                - type: SIMPLE_CHANGE
+              master_item:
+                key: '.1.3.6.1.4.1.37447.1.2.1.48.[{#SNMPINDEX}]'
+              tags:
+                - tag: Application
+                  value: 'Nimble OS'
+            - uuid: e67cae2b85b043d092395952e2cbf803
+              name: 'Nimble-OS::volIoWriteLatency100mTo200m.Delta[{#SNMPINDEX}]'
+              type: DEPENDENT
+              key: 'volIoWriteLatency100mTo200m.Delta[{#SNMPINDEX}]'
+              trends: '0'
+              description: 'Per-interval increase in the number of Write I/O operations with latency between 100 and 200 milliseconds.'
+              preprocessing:
+                - type: SIMPLE_CHANGE
+              master_item:
+                key: '.1.3.6.1.4.1.37447.1.2.1.49.[{#SNMPINDEX}]'
+              tags:
+                - tag: Application
+                  value: 'Nimble OS'
+            - uuid: 86fe0c19ea2545a18ca6e6b749433073
+              name: 'Nimble-OS::volIoWriteLatency100uTo200u.Delta[{#SNMPINDEX}]'
+              type: DEPENDENT
+              key: 'volIoWriteLatency100uTo200u.Delta[{#SNMPINDEX}]'
+              trends: '0'
+              description: 'Per-interval increase in the number of Write I/O operations with latency between 100 and 200 microseconds.'
+              preprocessing:
+                - type: SIMPLE_CHANGE
+              master_item:
+                key: '.1.3.6.1.4.1.37447.1.2.1.40.[{#SNMPINDEX}]'
+              tags:
+                - tag: Application
+                  value: 'Nimble OS'
+            - uuid: 9870bfe4a38f44ab8d07c0e5964a1fd3
+              name: 'Nimble-OS::volIoWriteLatency200mTo500m.Delta[{#SNMPINDEX}]'
+              type: DEPENDENT
+              key: 'volIoWriteLatency200mTo500m.Delta[{#SNMPINDEX}]'
+              trends: '0'
+              description: 'Per-interval increase in the number of Write I/O operations with latency between 200 and 500 milliseconds.'
+              preprocessing:
+                - type: SIMPLE_CHANGE
+              master_item:
+                key: '.1.3.6.1.4.1.37447.1.2.1.50.[{#SNMPINDEX}]'
+              tags:
+                - tag: Application
+                  value: 'Nimble OS'
+            - uuid: 96262aa815a64244bac046c431b9698e
+              name: 'Nimble-OS::volIoWriteLatency200uTo500u.Delta[{#SNMPINDEX}]'
+              type: DEPENDENT
+              key: 'volIoWriteLatency200uTo500u.Delta[{#SNMPINDEX}]'
+              trends: '0'
+              description: 'Per-interval increase in the number of Write I/O operations with latency between 200 and 500 microseconds.'
+              preprocessing:
+                - type: SIMPLE_CHANGE
+              master_item:
+                key: '.1.3.6.1.4.1.37447.1.2.1.41.[{#SNMPINDEX}]'
+              tags:
+                - tag: Application
+                  value: 'Nimble OS'
+            - uuid: 2d716937da9d4c14b2187f1c402f9c5e
+              name: 'Nimble-OS::volIoWriteLatency500mTomax.Delta[{#SNMPINDEX}]'
+              type: DEPENDENT
+              key: 'volIoWriteLatency500mTomax[{#SNMPINDEX}]'
+              trends: '0'
+              description: 'Per-interval increase in the number of Write I/O operations with latency above 500 milliseconds.'
+              preprocessing:
+                - type: SIMPLE_CHANGE
+              master_item:
+                key: '.1.3.6.1.4.1.37447.1.2.1.51.[{#SNMPINDEX}]'
+              tags:
+                - tag: Application
+                  value: 'Nimble OS'
+            - uuid: 9c36fae124894ecca9de5093adb1bc7d
+              name: 'Nimble-OS::volIoWriteLatency500uTo1m.Delta[{#SNMPINDEX}]'
+              type: DEPENDENT
+              key: 'volIoWriteLatency500uTo1m.Delta[{#SNMPINDEX}]'
+              trends: '0'
+              description: 'Per-interval increase in the number of Write I/O operations with latency between 1/2 and 1 milliseconds.'
+              preprocessing:
+                - type: SIMPLE_CHANGE
+              master_item:
+                key: '.1.3.6.1.4.1.37447.1.2.1.42.[{#SNMPINDEX}]'
+              tags:
+                - tag: Application
+                  value: 'Nimble OS'
+            - uuid: 4dca8ac5cd0d4e349f0305db3d930dd1
+              name: 'Nimble-OS::volIoWrites.Delta[{#SNMPINDEX}]'
+              type: DEPENDENT
+              key: 'volIoWrites.Delta[{#SNMPINDEX}]'
+              trends: '0'
+              description: 'Per-interval increase in the number of Write I/Os.'
+              preprocessing:
+                - type: SIMPLE_CHANGE
+              master_item:
+                key: '.1.3.6.1.4.1.37447.1.2.1.34.[{#SNMPINDEX}]'
+              tags:
+                - tag: Application
+                  value: 'Nimble OS'
+            - uuid: 2497c916efa64a1fb1d6e81bf31fe690
+              name: 'Nimble-OS::volloWriteTimeMicrosec.Delta[{#SNMPINDEX}]'
+              type: DEPENDENT
+              key: 'volloWriteTimeMicrosec.Delta[{#SNMPINDEX}]'
+              trends: '0'
+              units: ms
+              preprocessing:
+                - type: MULTIPLIER
+                  parameters:
+                    - '0.001'
+                - type: SIMPLE_CHANGE
+              master_item:
+                key: '.1.3.6.1.4.1.37447.1.2.1.35.[{#SNMPINDEX}]'
+              tags:
+                - tag: Application
+                  value: 'Nimble OS'
       tags:
-      - tag: Application
-        value: Nimble OS
-    - uuid: 0f71cb6f93a045f5b162d5494a5e0477
-      name: Nimble-OS::ioReads
-      type: SNMP_AGENT
-      snmp_oid: .1.3.6.1.4.1.37447.1.3.2.0
-      key: .1.3.6.1.4.1.37447.1.3.2.0
-      delay: 1m
-      history: 2w
-      trends: '0'
-      description: Total cumulative number of Read I/Os (sequential and random).
-      tags:
-      - tag: Application
-        value: Nimble OS
-    - uuid: 1ce2e6fbf7a04a78b89176ac8852456a
-      name: Nimble-OS::ioSeqReads
-      type: SNMP_AGENT
-      snmp_oid: .1.3.6.1.4.1.37447.1.3.3.0
-      key: .1.3.6.1.4.1.37447.1.3.3.0
-      delay: 1m
-      history: 2w
-      trends: '0'
-      description: Total cumulative number of Sequential Read I/Os.
-      tags:
-      - tag: Application
-        value: Nimble OS
-    - uuid: 0866490871724e78ad558bded69910c9
-      name: Nimble-OS::ioWrites
-      type: SNMP_AGENT
-      snmp_oid: .1.3.6.1.4.1.37447.1.3.4.0
-      key: .1.3.6.1.4.1.37447.1.3.4.0
-      delay: 1m
-      history: 2w
-      trends: '0'
-      description: Total cumulative number of Write I/Os.
-      tags:
-      - tag: Application
-        value: Nimble OS
-    - uuid: 54db1958a1e043ed81cc09d9c9730a35
-      name: Nimble-OS::ioSeqWrites
-      type: SNMP_AGENT
-      snmp_oid: .1.3.6.1.4.1.37447.1.3.5.0
-      key: .1.3.6.1.4.1.37447.1.3.5.0
-      delay: 1m
-      history: 2w
-      trends: '0'
-      description: Total cumulative number of Sequential Write I/Os.
-      tags:
-      - tag: Application
-        value: Nimble OS
-    - uuid: f463d114d06d40bfa1aa563399ad6792
-      name: Nimble-OS::ioReadTimeMicrosec
-      type: SNMP_AGENT
-      snmp_oid: .1.3.6.1.4.1.37447.1.3.6.0
-      key: .1.3.6.1.4.1.37447.1.3.6.0
-      delay: 1m
-      history: 2w
-      trends: '0'
-      units: ms
-      description: Total cumulative microseconds the system has spent processing Read
-        I/Os. This includes system and disk latency, but not any network latency back
-        to the initiator.
-      preprocessing:
-        - type: MULTIPLIER
-          parameters:
-            - '0.001'
-        - type: SIMPLE_CHANGE
-      tags:
-      - tag: Application
-        value: Nimble OS
-    - uuid: 79e57c62be894d80a093d395ab995a0b
-      name: Nimble-OS::ioWriteTimeMicrosec
-      type: SNMP_AGENT
-      snmp_oid: .1.3.6.1.4.1.37447.1.3.7.0
-      key: .1.3.6.1.4.1.37447.1.3.7.0
-      delay: 1m
-      history: 2w
-      trends: '0'
-      units: ms
-      description: Total cumulative microseconds the system has spent processing Write
-        I/Os. This includes system and disk latency, but not any network latency back
-        to the initiator.
-      preprocessing:
-        - type: MULTIPLIER
-          parameters:
-            - '0.001'
-        - type: SIMPLE_CHANGE
-      tags:
-      - tag: Application
-        value: Nimble OS
-    - uuid: 661e765a10934c0da170ee902ba509cf
-      name: Nimble-OS::ioReadBytes
-      type: SNMP_AGENT
-      snmp_oid: .1.3.6.1.4.1.37447.1.3.8.0
-      key: .1.3.6.1.4.1.37447.1.3.8.0
-      delay: 1m
-      history: 2w
-      trends: '0'
-      units: B
-      description: Total cumulative number of Read I/O bytes (sequential and random).
-      tags:
-      - tag: Application
-        value: Nimble OS
-    - uuid: c4a5510852cb4da492719eb8e0da5f19
-      name: Nimble-OS::ioSeqReadBytes
-      type: SNMP_AGENT
-      snmp_oid: .1.3.6.1.4.1.37447.1.3.9.0
-      key: .1.3.6.1.4.1.37447.1.3.9.0
-      delay: 1m
-      history: 2w
-      trends: '0'
-      units: B
-      description: Total cumulative number of Sequential Read I/O bytes.
-      tags:
-      - tag: Application
-        value: Nimble OS
-    - uuid: 2351c4d411424eae9fb03bbc42c06500
-      name: Nimble-OS::ioWriteBytes
-      type: SNMP_AGENT
-      snmp_oid: .1.3.6.1.4.1.37447.1.3.10.0
-      key: .1.3.6.1.4.1.37447.1.3.10.0
-      delay: 1m
-      history: 2w
-      trends: '0'
-      units: B
-      description: Total cumulative number of Write I/O bytes (sequential and random).
-      tags:
-      - tag: Application
-        value: Nimble OS
-    - uuid: f5f9ded8ebec43efafd3cfd43f3946db
-      name: Nimble-OS::ioSeqWriteBytes
-      type: SNMP_AGENT
-      snmp_oid: .1.3.6.1.4.1.37447.1.3.11.0
-      key: .1.3.6.1.4.1.37447.1.3.11.0
-      delay: 1m
-      history: 2w
-      trends: '0'
-      units: B
-      description: Total cumulative number of Sequential Write I/O bytes.
-      tags:
-      - tag: Application
-        value: Nimble OS
-    - uuid: 1d66e656c4a7478b93e8264eb59c2425
-      name: Nimble-OS::diskVolBytesUsedLow
-      type: SNMP_AGENT
-      snmp_oid: .1.3.6.1.4.1.37447.1.3.12.0
-      key: .1.3.6.1.4.1.37447.1.3.12.0
-      delay: 1m
-      history: 2w
-      trends: '0'
-      units: B
-      description: Total number of bytes used on disk for volumes - low order bytes.
-      tags:
-      - tag: Application
-        value: Nimble OS
-    - uuid: f1d1faa3ca824b9ba4eb52340c12c50c
-      name: Nimble-OS::diskVolBytesUsedHigh
-      type: SNMP_AGENT
-      snmp_oid: .1.3.6.1.4.1.37447.1.3.13.0
-      key: .1.3.6.1.4.1.37447.1.3.13.0
-      delay: 1m
-      history: 2w
-      trends: '0'
-      units: B
-      description: Total number of bytes used on disk for volumes - high order bytes.
-      tags:
-      - tag: Application
-        value: Nimble OS
-    - uuid: e024111045d74b359950b3d2fb8adc98
-      name: Nimble-OS::diskSnapBytesUsedLow
-      type: SNMP_AGENT
-      snmp_oid: .1.3.6.1.4.1.37447.1.3.14.0
-      key: .1.3.6.1.4.1.37447.1.3.14.0
-      delay: 1m
-      history: 2w
-      trends: '0'
-      units: B
-      description: Total number of bytes used on disk for snapshots - low order bytes.
-      tags:
-      - tag: Application
-        value: Nimble OS
-    - uuid: 543ef43778ba483f804aeae2a8a89de6
-      name: Nimble-OS::diskSnapBytesUsedHigh
-      type: SNMP_AGENT
-      snmp_oid: .1.3.6.1.4.1.37447.1.3.15.0
-      key: .1.3.6.1.4.1.37447.1.3.15.0
-      delay: 1m
-      history: 2w
-      trends: '0'
-      units: B
-      description: Total number of bytes used on disk for snapshots - high order bytes.
-      tags:
-      - tag: Application
-        value: Nimble OS
-    - uuid: 9e626a7aa79147e8ab2c624070fc08a2
-      name: Nimble-OS::ioNonseqReadHits
-      type: SNMP_AGENT
-      snmp_oid: .1.3.6.1.4.1.37447.1.3.16.0
-      key: .1.3.6.1.4.1.37447.1.3.16.0
-      delay: 1m
-      history: 2w
-      value_type: FLOAT
-      trends: '0'
-      description: Total cumulative number of cache hits for Non-Sequential Read I/Os.
-      tags: []
-    discovery_rules:
-    - uuid: a9b613800fb0435cb49630460168995b
-      name: Nimble-OS::volTable
-      type: SNMP_AGENT
-      snmp_oid: discovery[{#VOLID},.1.3.6.1.4.1.37447.1.2.1.2,{#VOLNAME},.1.3.6.1.4.1.37447.1.2.1.3,{#VOLSIZELOW},.1.3.6.1.4.1.37447.1.2.1.4,{#VOLSIZEHIGH},.1.3.6.1.4.1.37447.1.2.1.5,{#VOLUSAGELOW},.1.3.6.1.4.1.37447.1.2.1.6,{#VOLUSAGEHIGH},.1.3.6.1.4.1.37447.1.2.1.7,{#VOLRESERVELOW},.1.3.6.1.4.1.37447.1.2.1.8,{#VOLRESERVEHIGH},.1.3.6.1.4.1.37447.1.2.1.9,{#VOLONLINE},.1.3.6.1.4.1.37447.1.2.1.10,{#VOLNUMCONNECTIONS},.1.3.6.1.4.1.37447.1.2.1.11,{#VOLSTATTIMEEPOCHSECONDS},.1.3.6.1.4.1.37447.1.2.1.12]
-      key: .1.3.6.1.4.1.37447.1.2
-      delay: '3600'
-      lifetime: 30d
-      enabled_lifetime_type: DISABLE_NEVER
-      description: Volume information table.
-      item_prototypes:
-      - uuid: a75f535f2ee04a6cb360ee09b2748b59
-        name: Nimble-OS::volID[{#SNMPINDEX}]
-        type: SNMP_AGENT
-        snmp_oid: .1.3.6.1.4.1.37447.1.2.1.2.{#SNMPINDEX}
-        key: .1.3.6.1.4.1.37447.1.2.1.2.[{#SNMPINDEX}]
-        delay: 1m
-        history: 2w
-        value_type: FLOAT
-        trends: '0'
-        description: Volume ID.
-        tags:
-        - tag: Application
-          value: Nimble OS
-      - uuid: acf8f34817eb497e8b27813b555615d1
-        name: Nimble-OS::volName[{#SNMPINDEX}]
-        type: SNMP_AGENT
-        snmp_oid: .1.3.6.1.4.1.37447.1.2.1.3.{#SNMPINDEX}
-        key: .1.3.6.1.4.1.37447.1.2.1.3.[{#SNMPINDEX}]
-        delay: 1m
-        history: 2w
-        value_type: TEXT
-        description: Volume Name.
-        tags:
-        - tag: Application
-          value: Nimble OS
-      - uuid: ab57e6cd39c14b1a82ad03449777f2e1
-        name: Nimble-OS::volSizeLow[{#SNMPINDEX}]
-        type: SNMP_AGENT
-        snmp_oid: .1.3.6.1.4.1.37447.1.2.1.4.{#SNMPINDEX}
-        key: .1.3.6.1.4.1.37447.1.2.1.4.[{#SNMPINDEX}]
-        delay: 1m
-        history: 2w
-        value_type: FLOAT
-        trends: '0'
-        units: B
-        description: Maximum defined size of a volume in bytes - low order bytes.
-        tags:
-        - tag: Application
-          value: Nimble OS
-      - uuid: 6e04631ec2cd4f869c9db2a7d0ed002b
-        name: Nimble-OS::volSizeHigh[{#SNMPINDEX}]
-        type: SNMP_AGENT
-        snmp_oid: .1.3.6.1.4.1.37447.1.2.1.5.{#SNMPINDEX}
-        key: .1.3.6.1.4.1.37447.1.2.1.5.[{#SNMPINDEX}]
-        delay: 1m
-        history: 2w
-        value_type: FLOAT
-        trends: '0'
-        units: B
-        description: Maximum defined size of a volume in bytes - high order bytes.
-        tags:
-        - tag: Application
-          value: Nimble OS
-      - uuid: b8e0adad6a68480e9a54fc6c266cf787
-        name: Nimble-OS::volUsageLow[{#SNMPINDEX}]
-        type: SNMP_AGENT
-        snmp_oid: .1.3.6.1.4.1.37447.1.2.1.6.{#SNMPINDEX}
-        key: .1.3.6.1.4.1.37447.1.2.1.6.[{#SNMPINDEX}]
-        delay: 1m
-        history: 2w
-        value_type: FLOAT
-        trends: '0'
-        units: B
-        description: Current number of bytes a volume is using - low order bytes.
-        tags:
-        - tag: Application
-          value: Nimble OS
-      - uuid: e2bd9945deb34ee69c281dcc2a76a3d9
-        name: Nimble-OS::volUsageHigh[{#SNMPINDEX}]
-        type: SNMP_AGENT
-        snmp_oid: .1.3.6.1.4.1.37447.1.2.1.7.{#SNMPINDEX}
-        key: .1.3.6.1.4.1.37447.1.2.1.7.[{#SNMPINDEX}]
-        delay: 1m
-        history: 2w
-        value_type: FLOAT
-        trends: '0'
-        units: B
-        description: Current number of bytes a volume is using - high order bytes.
-        tags:
-        - tag: Application
-          value: Nimble OS
-      - uuid: 1a05c86a222f46d6800df6b14af75a6a
-        name: Nimble-OS::volReserveLow[{#SNMPINDEX}]
-        type: SNMP_AGENT
-        snmp_oid: .1.3.6.1.4.1.37447.1.2.1.8.{#SNMPINDEX}
-        key: .1.3.6.1.4.1.37447.1.2.1.8.[{#SNMPINDEX}]
-        delay: 1m
-        history: 2w
-        value_type: FLOAT
-        trends: '0'
-        units: B
-        description: Number of bytes reserved for a volume - low order bytes.
-        tags:
-        - tag: Application
-          value: Nimble OS
-      - uuid: 4fb41824305e424bb471da9473d2baec
-        name: Nimble-OS::volReserveHigh[{#SNMPINDEX}]
-        type: SNMP_AGENT
-        snmp_oid: .1.3.6.1.4.1.37447.1.2.1.9.{#SNMPINDEX}
-        key: .1.3.6.1.4.1.37447.1.2.1.9.[{#SNMPINDEX}]
-        delay: 1m
-        history: 2w
-        value_type: FLOAT
-        trends: '0'
-        units: B
-        description: Number of bytes reserved for a volume - high order bytes.
-        tags:
-        - tag: Application
-          value: Nimble OS
-      - uuid: 9e68c0df6c3245a7a9e5aee12c4b9875
-        name: Nimble-OS::volOnline[{#SNMPINDEX}]
-        type: SNMP_AGENT
-        snmp_oid: .1.3.6.1.4.1.37447.1.2.1.10.{#SNMPINDEX}
-        key: .1.3.6.1.4.1.37447.1.2.1.10.[{#SNMPINDEX}]
-        delay: 1m
-        history: 2w
-        value_type: FLOAT
-        trends: '0'
-        description: Volume Online (true or false).
-        valuemap:
-          name: Nimble-OS::volOnline
-        tags:
-        - tag: Application
-          value: Nimble OS
-      - uuid: aa14fd14fa5e4e81afeca9a54c2c4c1d
-        name: Nimble-OS::volNumConnections[{#SNMPINDEX}]
-        type: SNMP_AGENT
-        snmp_oid: .1.3.6.1.4.1.37447.1.2.1.11.{#SNMPINDEX}
-        key: .1.3.6.1.4.1.37447.1.2.1.11.[{#SNMPINDEX}]
-        delay: 1m
-        history: 2w
-        value_type: FLOAT
-        trends: '0'
-        description: Number of iSCSI connections to the volume.
-        tags:
-        - tag: Application
-          value: Nimble OS
-      - uuid: 41cf08abb9f54c56a9679cf584c4e405
-        name: Nimble-OS::volStatTimeEpochSeconds[{#SNMPINDEX}]
-        type: SNMP_AGENT
-        snmp_oid: .1.3.6.1.4.1.37447.1.2.1.12.{#SNMPINDEX}
-        key: .1.3.6.1.4.1.37447.1.2.1.12.[{#SNMPINDEX}]
-        delay: 1m
-        history: 2w
-        units: unixtime
-        value_type: FLOAT
-        description: Time at which the sample was taken, measured in seconds since
-          UNIX epoch.
-        tags:
-        - tag: Application
-          value: Nimble OS
-      - uuid: 3eb16a72d27741ce9ae915deec5f3133
-        name: Nimble-OS::volIoReads[{#SNMPINDEX}]
-        type: SNMP_AGENT
-        snmp_oid: .1.3.6.1.4.1.37447.1.2.1.13.{#SNMPINDEX}
-        key: .1.3.6.1.4.1.37447.1.2.1.13.[{#SNMPINDEX}]
-        delay: 1m
-        history: 2w
-        value_type: FLOAT
-        trends: '0'
-        description: Total cumulative number of Read I/Os (sequential and random).
-        tags:
-        - tag: Application
-          value: Nimble OS
-      - uuid: 9957a27e857e48588a3aff460f3c3c2a
-        name: Nimble-OS::volIoReadTimeMicrosec[{#SNMPINDEX}]
-        type: SNMP_AGENT
-        snmp_oid: .1.3.6.1.4.1.37447.1.2.1.14.{#SNMPINDEX}
-        key: .1.3.6.1.4.1.37447.1.2.1.14.[{#SNMPINDEX}]
-        delay: 1m
-        history: 2w
-        value_type: FLOAT
-        trends: '0'
-        units: ms
-        description: Total cumulative time for Read operation (sequential and random).
-        preprocessing:
-        - type: MULTIPLIER
-          parameters:
-            - '0.001'
-        - type: SIMPLE_CHANGE
-        tags:
-        - tag: Application
-          value: Nimble OS
-      - uuid: a681f67fae74473d94b8a48fd716cc87
-        name: Nimble-OS::volIoReadBytes[{#SNMPINDEX}]
-        type: SNMP_AGENT
-        snmp_oid: .1.3.6.1.4.1.37447.1.2.1.15.{#SNMPINDEX}
-        key: .1.3.6.1.4.1.37447.1.2.1.15.[{#SNMPINDEX}]
-        delay: 1m
-        history: 2w
-        value_type: FLOAT
-        trends: '0'
-        units: B
-        description: Total cumulative number of Read I/O bytes (sequential and random).
-        tags:
-        - tag: Application
-          value: Nimble OS
-      - uuid: efa037550902496c995ab5ddd27c0908
-        name: Nimble-OS::volIoSeqReads[{#SNMPINDEX}]
-        type: SNMP_AGENT
-        snmp_oid: .1.3.6.1.4.1.37447.1.2.1.16.{#SNMPINDEX}
-        key: .1.3.6.1.4.1.37447.1.2.1.16.[{#SNMPINDEX}]
-        delay: 1m
-        history: 2w
-        value_type: FLOAT
-        trends: '0'
-        description: Total Number of Sequential Read I/O operations.
-        tags:
-        - tag: Application
-          value: Nimble OS
-      - uuid: f322715c64294d63996527813d5f5859
-        name: Nimble-OS::volIoSeqReadBytes[{#SNMPINDEX}]
-        type: SNMP_AGENT
-        snmp_oid: .1.3.6.1.4.1.37447.1.2.1.17.{#SNMPINDEX}
-        key: .1.3.6.1.4.1.37447.1.2.1.17.[{#SNMPINDEX}]
-        delay: 1m
-        history: 2w
-        value_type: FLOAT
-        trends: '0'
-        units: B
-        description: Total cumulative number of Sequential Read I/O bytes.
-        tags:
-        - tag: Application
-          value: Nimble OS
-      - uuid: 04f31e9b0a434c80ad59f1272f1bda74
-        name: Nimble-OS::volIoNonseqReadTotalHits[{#SNMPINDEX}]
-        type: SNMP_AGENT
-        snmp_oid: .1.3.6.1.4.1.37447.1.2.1.18.{#SNMPINDEX}
-        key: .1.3.6.1.4.1.37447.1.2.1.18.[{#SNMPINDEX}]
-        delay: 1m
-        history: 2w
-        value_type: FLOAT
-        description: Total number of Nonsequential Read I/O hits (to Memory and SSD).
-        tags:
-        - tag: Application
-          value: Nimble OS
-      - uuid: c30f6388046f41449842ca573fb28a2f
-        name: Nimble-OS::volIoNonseqReadMemHits[{#SNMPINDEX}]
-        type: SNMP_AGENT
-        snmp_oid: .1.3.6.1.4.1.37447.1.2.1.19.{#SNMPINDEX}
-        key: .1.3.6.1.4.1.37447.1.2.1.19.[{#SNMPINDEX}]
-        delay: 1m
-        history: 2w
-        value_type: FLOAT
-        trends: '0'
-        description: Total number of Nonsequential Read I/O hits to Memory.
-        tags:
-        - tag: Application
-          value: Nimble OS
-      - uuid: eff76e80740846fba7459d040cce8d73
-        name: Nimble-OS::volIoNonseqReadSSDHits[{#SNMPINDEX}]
-        type: SNMP_AGENT
-        snmp_oid: .1.3.6.1.4.1.37447.1.2.1.20.{#SNMPINDEX}
-        key: .1.3.6.1.4.1.37447.1.2.1.20.[{#SNMPINDEX}]
-        delay: 1m
-        history: 2w
-        value_type: FLOAT
-        trends: '0'
-        description: Total number of Nonsequential Read I/O hits to SSD.
-        tags:
-        - tag: Application
-          value: Nimble OS
-      - uuid: 44ce809f8ea540a29bdfa6e2d6f3c212
-        name: Nimble-OS::volIoReadLatency0uTo100u[{#SNMPINDEX}]
-        type: SNMP_AGENT
-        snmp_oid: .1.3.6.1.4.1.37447.1.2.1.21.{#SNMPINDEX}
-        key: .1.3.6.1.4.1.37447.1.2.1.21.[{#SNMPINDEX}]
-        delay: 1m
-        history: 2w
-        value_type: FLOAT
-        trends: '0'
-        description: Number of Read I/O operations with latency between 0 and 100
-          microseconds.
-        tags:
-        - tag: Application
-          value: Nimble OS
-      - uuid: 0595148f41a046ef9f3ca40a88525b46
-        name: Nimble-OS::volIoReadLatency100uTo200u[{#SNMPINDEX}]
-        type: SNMP_AGENT
-        snmp_oid: .1.3.6.1.4.1.37447.1.2.1.22.{#SNMPINDEX}
-        key: .1.3.6.1.4.1.37447.1.2.1.22.[{#SNMPINDEX}]
-        delay: 1m
-        history: 2w
-        value_type: FLOAT
-        trends: '0'
-        description: Number of Read I/O operations with latency between 100 and 200
-          microseconds.
-        tags:
-        - tag: Application
-          value: Nimble OS
-      - uuid: 184c0025750d4d35b5d62d4e44631455
-        name: Nimble-OS::volIoReadLatency200uTo500u[{#SNMPINDEX}]
-        type: SNMP_AGENT
-        snmp_oid: .1.3.6.1.4.1.37447.1.2.1.23.{#SNMPINDEX}
-        key: .1.3.6.1.4.1.37447.1.2.1.23.[{#SNMPINDEX}]
-        delay: 1m
-        history: 2w
-        value_type: FLOAT
-        trends: '0'
-        description: Number of Read I/O operations with latency between 200 and 500
-          microseconds.
-        tags:
-        - tag: Application
-          value: Nimble OS
-      - uuid: c2946abd5cea443784c239b70645e3ca
-        name: Nimble-OS::volIoReadLatency500uTo1m[{#SNMPINDEX}]
-        type: SNMP_AGENT
-        snmp_oid: .1.3.6.1.4.1.37447.1.2.1.24.{#SNMPINDEX}
-        key: .1.3.6.1.4.1.37447.1.2.1.24.[{#SNMPINDEX}]
-        delay: 1m
-        history: 2w
-        value_type: FLOAT
-        trends: '0'
-        description: Number of Read I/O operations with latency between 1/2 and 1
-          milliseconds.
-        tags:
-        - tag: Application
-          value: Nimble OS
-      - uuid: f3d1c4f3b7fa4bc6ba3f3bdcf5271118
-        name: Nimble-OS::volIoReadLatency1mTo2m[{#SNMPINDEX}]
-        type: SNMP_AGENT
-        snmp_oid: .1.3.6.1.4.1.37447.1.2.1.25.{#SNMPINDEX}
-        key: .1.3.6.1.4.1.37447.1.2.1.25.[{#SNMPINDEX}]
-        delay: 1m
-        history: 2w
-        value_type: FLOAT
-        trends: '0'
-        description: Number of Read I/O operations with latency between 1 and 2 milliseconds.
-        tags:
-        - tag: Application
-          value: Nimble OS
-      - uuid: a17a78edaf8e4434bd76c1029099d99d
-        name: Nimble-OS::volIoReadLatency2mTo5m[{#SNMPINDEX}]
-        type: SNMP_AGENT
-        snmp_oid: .1.3.6.1.4.1.37447.1.2.1.26.{#SNMPINDEX}
-        key: .1.3.6.1.4.1.37447.1.2.1.26.[{#SNMPINDEX}]
-        delay: 1m
-        history: 2w
-        value_type: FLOAT
-        trends: '0'
-        description: Number of Read I/O operations with latency between 2 and 5 milliseconds.
-        tags:
-        - tag: Application
-          value: Nimble OS
-      - uuid: 197c95ba262f4829a12ac82b0d74b200
-        name: Nimble-OS::volIoReadLatency5mTo10m[{#SNMPINDEX}]
-        type: SNMP_AGENT
-        snmp_oid: .1.3.6.1.4.1.37447.1.2.1.27.{#SNMPINDEX}
-        key: .1.3.6.1.4.1.37447.1.2.1.27.[{#SNMPINDEX}]
-        delay: 1m
-        history: 2w
-        value_type: FLOAT
-        trends: '0'
-        description: Number of Read I/O operations with latency between 5 and 10 milliseconds.
-        tags:
-        - tag: Application
-          value: Nimble OS
-      - uuid: 5776ada41ee44f89bdc936041df4fa5e
-        name: Nimble-OS::volIoReadLatency10mTo20m[{#SNMPINDEX}]
-        type: SNMP_AGENT
-        snmp_oid: .1.3.6.1.4.1.37447.1.2.1.28.{#SNMPINDEX}
-        key: .1.3.6.1.4.1.37447.1.2.1.28.[{#SNMPINDEX}]
-        delay: 1m
-        history: 2w
-        value_type: FLOAT
-        trends: '0'
-        description: Number of Read I/O operations with latency between 10 and 20
-          milliseconds.
-        tags:
-        - tag: Application
-          value: Nimble OS
-      - uuid: 8ab9839beb374963a787a386355e62ef
-        name: Nimble-OS::volIoReadLatency20mTo50m[{#SNMPINDEX}]
-        type: SNMP_AGENT
-        snmp_oid: .1.3.6.1.4.1.37447.1.2.1.29.{#SNMPINDEX}
-        key: .1.3.6.1.4.1.37447.1.2.1.29.[{#SNMPINDEX}]
-        delay: 1m
-        history: 2w
-        value_type: FLOAT
-        trends: '0'
-        description: Number of Read I/O operations with latency between 20 and 50
-          milliseconds.
-        tags:
-        - tag: Application
-          value: Nimble OS
-      - uuid: 377346e621854ceb979ae87bbb54bc01
-        name: Nimble-OS::volIoReadLatency50mTo100m[{#SNMPINDEX}]
-        type: SNMP_AGENT
-        snmp_oid: .1.3.6.1.4.1.37447.1.2.1.30.{#SNMPINDEX}
-        key: .1.3.6.1.4.1.37447.1.2.1.30.[{#SNMPINDEX}]
-        delay: 1m
-        history: 2w
-        value_type: FLOAT
-        trends: '0'
-        description: Number of Read I/O operations with latency between 50 and 100
-          milliseconds.
-        tags:
-        - tag: Application
-          value: Nimble OS
-      - uuid: 909932ad797d47828f667475235a16a7
-        name: Nimble-OS::volIoReadLatency100mTo200m[{#SNMPINDEX}]
-        type: SNMP_AGENT
-        snmp_oid: .1.3.6.1.4.1.37447.1.2.1.31.{#SNMPINDEX}
-        key: .1.3.6.1.4.1.37447.1.2.1.31.[{#SNMPINDEX}]
-        delay: 1m
-        history: 2w
-        value_type: FLOAT
-        trends: '0'
-        description: Number of Read I/O operations with latency between 100 and 200
-          milliseconds.
-        tags:
-        - tag: Application
-          value: Nimble OS
-      - uuid: c1d0af8d0ff849f785a36bb325161851
-        name: Nimble-OS::volIoReadLatency200mTo500m[{#SNMPINDEX}]
-        type: SNMP_AGENT
-        snmp_oid: .1.3.6.1.4.1.37447.1.2.1.32.{#SNMPINDEX}
-        key: .1.3.6.1.4.1.37447.1.2.1.32.[{#SNMPINDEX}]
-        delay: 1m
-        history: 2w
-        value_type: FLOAT
-        trends: '0'
-        description: Number of Read I/O operations with latency between 200 and 500
-          milliseconds.
-        tags:
-        - tag: Application
-          value: Nimble OS
-      - uuid: d0c488891ef541d8b8badc4565c33f0e
-        name: Nimble-OS::volIoReadLatency500mTomax[{#SNMPINDEX}]
-        type: SNMP_AGENT
-        snmp_oid: .1.3.6.1.4.1.37447.1.2.1.33.{#SNMPINDEX}
-        key: .1.3.6.1.4.1.37447.1.2.1.33.[{#SNMPINDEX}]
-        delay: 1m
-        history: 2w
-        value_type: FLOAT
-        trends: '0'
-        description: Number of Read I/O operations with latency above 500 milliseconds.
-        tags:
-        - tag: Application
-          value: Nimble OS
-      - uuid: b884f037aaa144a9b40084321aa618cb
-        name: Nimble-OS::volIoWrites[{#SNMPINDEX}]
-        type: SNMP_AGENT
-        snmp_oid: .1.3.6.1.4.1.37447.1.2.1.34.{#SNMPINDEX}
-        key: .1.3.6.1.4.1.37447.1.2.1.34.[{#SNMPINDEX}]
-        delay: 1m
-        history: 2w
-        value_type: FLOAT
-        description: Total cumulative number of Write I/Os.
-        tags:
-        - tag: Application
-          value: Nimble OS
-      - uuid: e959f7cc290f4b6eba18451a2b9c18bb
-        name: Nimble-OS::volIoWriteTimeMicrosec[{#SNMPINDEX}]
-        type: SNMP_AGENT
-        snmp_oid: .1.3.6.1.4.1.37447.1.2.1.35.{#SNMPINDEX}
-        key: .1.3.6.1.4.1.37447.1.2.1.35.[{#SNMPINDEX}]
-        delay: 1m
-        history: 2w
-        units: ms
-        value_type: FLOAT
-        description: Total cumulative time for Write operation (sequential and random).
-        tags:
-        - tag: Application
-          value: Nimble OS
-      - uuid: cb4ded6313264ea3933613a6a59328e0
-        name: Nimble-OS::volIoWriteBytes[{#SNMPINDEX}]
-        type: SNMP_AGENT
-        snmp_oid: .1.3.6.1.4.1.37447.1.2.1.36.{#SNMPINDEX}
-        key: .1.3.6.1.4.1.37447.1.2.1.36.[{#SNMPINDEX}]
-        delay: 1m
-        history: 2w
-        value_type: FLOAT
-        trends: '0'
-        units: B
-        description: Total cumulative number of Write I/O bytes (sequential and random).
-        tags:
-        - tag: Application
-          value: Nimble OS
-      - uuid: 0ae806181724465bbe0424f6883f5ccb
-        name: Nimble-OS::volIoSeqWrites[{#SNMPINDEX}]
-        type: SNMP_AGENT
-        snmp_oid: .1.3.6.1.4.1.37447.1.2.1.37.{#SNMPINDEX}
-        key: .1.3.6.1.4.1.37447.1.2.1.37.[{#SNMPINDEX}]
-        delay: 1m
-        history: 2w
-        value_type: FLOAT
-        trends: '0'
-        description: Total Number of Sequential Write I/O operations.
-        tags:
-        - tag: Application
-          value: Nimble OS
-      - uuid: 726e18eb993a48aab100c27135b66502
-        name: Nimble-OS::volIoSeqWriteBytes[{#SNMPINDEX}]
-        type: SNMP_AGENT
-        snmp_oid: .1.3.6.1.4.1.37447.1.2.1.38.{#SNMPINDEX}
-        key: .1.3.6.1.4.1.37447.1.2.1.38.[{#SNMPINDEX}]
-        delay: 1m
-        history: 2w
-        value_type: FLOAT
-        trends: '0'
-        units: B
-        description: Number of Sequential Write I/O bytes.
-        tags:
-        - tag: Application
-          value: Nimble OS
-      - uuid: f3c81524a29945fb827d3047284428d5
-        name: Nimble-OS::volIoWriteLatency0uTo100u[{#SNMPINDEX}]
-        type: SNMP_AGENT
-        snmp_oid: .1.3.6.1.4.1.37447.1.2.1.39.{#SNMPINDEX}
-        key: .1.3.6.1.4.1.37447.1.2.1.39.[{#SNMPINDEX}]
-        delay: 1m
-        history: 2w
-        value_type: FLOAT
-        trends: '0'
-        description: Number of Write I/O operations with latency between 0 and 100
-          microseconds.
-        tags:
-        - tag: Application
-          value: Nimble OS
-      - uuid: ec1fdf6ecd904a55bf47d808baece0fe
-        name: Nimble-OS::volIoWriteLatency100uTo200u[{#SNMPINDEX}]
-        type: SNMP_AGENT
-        snmp_oid: .1.3.6.1.4.1.37447.1.2.1.40.{#SNMPINDEX}
-        key: .1.3.6.1.4.1.37447.1.2.1.40.[{#SNMPINDEX}]
-        delay: 1m
-        history: 2w
-        value_type: FLOAT
-        trends: '0'
-        description: Number of Write I/O operations with latency between 100 and 200
-        tags:
-        - tag: Application
-          value: Nimble OS
-      - uuid: cf4ac1bf942843cfacc571555f646937
-        name: Nimble-OS::volIoWriteLatency200uTo500u[{#SNMPINDEX}]
-        type: SNMP_AGENT
-        snmp_oid: .1.3.6.1.4.1.37447.1.2.1.41.{#SNMPINDEX}
-        key: .1.3.6.1.4.1.37447.1.2.1.41.[{#SNMPINDEX}]
-        delay: 1m
-        history: 2w
-        value_type: FLOAT
-        trends: '0'
-        description: Number of Write I/O operations with latency between 200 and 500
-          microseconds.
-        tags:
-        - tag: Application
-          value: Nimble OS
-      - uuid: c1a01cb349ff454792f0984dbd161494
-        name: Nimble-OS::volIoWriteLatency500uTo1m[{#SNMPINDEX}]
-        type: SNMP_AGENT
-        snmp_oid: .1.3.6.1.4.1.37447.1.2.1.42.{#SNMPINDEX}
-        key: .1.3.6.1.4.1.37447.1.2.1.42.[{#SNMPINDEX}]
-        delay: 1m
-        history: 2w
-        value_type: FLOAT
-        description: Number of Write I/O operations with latency between 1/2 and 1
-          milliseconds.
-        tags:
-        - tag: Application
-          value: Nimble OS
-      - uuid: 25323e43edf54d308b2e3f2c4f77d343
-        name: Nimble-OS::volIoWriteLatency1mTo2m[{#SNMPINDEX}]
-        type: SNMP_AGENT
-        snmp_oid: .1.3.6.1.4.1.37447.1.2.1.43.{#SNMPINDEX}
-        key: .1.3.6.1.4.1.37447.1.2.1.43.[{#SNMPINDEX}]
-        delay: 1m
-        history: 2w
-        value_type: FLOAT
-        trends: '0'
-        description: Number of Write I/O operations with latency between 1 and 2 milliseconds.
-        tags:
-        - tag: Application
-          value: Nimble OS
-      - uuid: 288eac5a74454570b740c20f63738103
-        name: Nimble-OS::volIoWriteLatency2mTo5m[{#SNMPINDEX}]
-        type: SNMP_AGENT
-        snmp_oid: .1.3.6.1.4.1.37447.1.2.1.44.{#SNMPINDEX}
-        key: .1.3.6.1.4.1.37447.1.2.1.44.[{#SNMPINDEX}]
-        delay: 1m
-        history: 2w
-        value_type: FLOAT
-        trends: '0'
-        description: Number of Write I/O operations with latency between 2 and 5 milliseconds.
-        tags:
-        - tag: Application
-          value: Nimble OS
-      - uuid: 3993c03618e2429290e8e96b619713e0
-        name: Nimble-OS::volIoWriteLatency5mTo10m[{#SNMPINDEX}]
-        type: SNMP_AGENT
-        snmp_oid: .1.3.6.1.4.1.37447.1.2.1.45.{#SNMPINDEX}
-        key: .1.3.6.1.4.1.37447.1.2.1.45.[{#SNMPINDEX}]
-        delay: 1m
-        history: 2w
-        value_type: FLOAT
-        trends: '0'
-        description: Number of Write I/O operations with latency between 5 and 10
-          milliseconds.
-        tags:
-        - tag: Application
-          value: Nimble OS
-      - uuid: 197921ca1b2441d08856f3d317084138
-        name: Nimble-OS::volIoWriteLatency10mTo20m[{#SNMPINDEX}]
-        type: SNMP_AGENT
-        snmp_oid: .1.3.6.1.4.1.37447.1.2.1.46.{#SNMPINDEX}
-        key: .1.3.6.1.4.1.37447.1.2.1.46.[{#SNMPINDEX}]
-        delay: 1m
-        history: 2w
-        value_type: FLOAT
-        trends: '0'
-        description: Number of Write I/O operations with latency between 10 and 20
-          milliseconds.
-        tags:
-        - tag: Application
-          value: Nimble OS
-      - uuid: 22c96dc33f074c27adb0f528e1537307
-        name: Nimble-OS::volIoWriteLatency20mTo50m[{#SNMPINDEX}]
-        type: SNMP_AGENT
-        snmp_oid: .1.3.6.1.4.1.37447.1.2.1.47.{#SNMPINDEX}
-        key: .1.3.6.1.4.1.37447.1.2.1.47.[{#SNMPINDEX}]
-        delay: 1m
-        history: 2w
-        value_type: FLOAT
-        trends: '0'
-        description: Number of Write I/O operations with latency between 20 and 50
-          milliseconds.
-        tags:
-        - tag: Application
-          value: Nimble OS
-      - uuid: 5ded4f137ced4e98b48f44ad3a4573d4
-        name: Nimble-OS::volIoWriteLatency50mTo100m[{#SNMPINDEX}]
-        type: SNMP_AGENT
-        snmp_oid: .1.3.6.1.4.1.37447.1.2.1.48.{#SNMPINDEX}
-        key: .1.3.6.1.4.1.37447.1.2.1.48.[{#SNMPINDEX}]
-        delay: 1m
-        history: 2w
-        value_type: FLOAT
-        trends: '0'
-        description: Number of Write I/O operations with latency between 50 and 100
-          milliseconds.
-        tags:
-        - tag: Application
-          value: Nimble OS
-      - uuid: 6fdce410a8c143b68bc55009044271d3
-        name: Nimble-OS::volIoWriteLatency100mTo200m[{#SNMPINDEX}]
-        type: SNMP_AGENT
-        snmp_oid: .1.3.6.1.4.1.37447.1.2.1.49.{#SNMPINDEX}
-        key: .1.3.6.1.4.1.37447.1.2.1.49.[{#SNMPINDEX}]
-        delay: 1m
-        history: 2w
-        value_type: FLOAT
-        trends: '0'
-        description: Number of Write I/O operations with latency between 100 and 200
-          milliseconds.
-        tags:
-        - tag: Application
-          value: Nimble OS
-      - uuid: 1db071e1f47c42fb8917b3e0b08d8abb
-        name: Nimble-OS::volIoWriteLatency200mTo500m[{#SNMPINDEX}]
-        type: SNMP_AGENT
-        snmp_oid: .1.3.6.1.4.1.37447.1.2.1.50.{#SNMPINDEX}
-        key: .1.3.6.1.4.1.37447.1.2.1.50.[{#SNMPINDEX}]
-        delay: 1m
-        history: 2w
-        value_type: FLOAT
-        trends: '0'
-        description: Number of Write I/O operations with latency between 200 and 500
-          milliseconds.
-        tags:
-        - tag: Application
-          value: Nimble OS
-      - uuid: 0e5ef32270814e3d91aac2b01faac6be
-        name: Nimble-OS::volIoWriteLatency500mTomax[{#SNMPINDEX}]
-        type: SNMP_AGENT
-        snmp_oid: .1.3.6.1.4.1.37447.1.2.1.51.{#SNMPINDEX}
-        key: .1.3.6.1.4.1.37447.1.2.1.51.[{#SNMPINDEX}]
-        delay: 1m
-        history: 2w
-        value_type: FLOAT
-        trends: '0'
-        description: Number of Write I/O operations with latency above 500 milliseconds.
-        tags:
-        - tag: Application
-          value: Nimble OS
-      - uuid: a17c6405c9a749d3b2838542e89f3ebb
-        name: Nimble-OS::volDiskVolBytesUsedLow[{#SNMPINDEX}]
-        type: SNMP_AGENT
-        snmp_oid: .1.3.6.1.4.1.37447.1.2.1.52.{#SNMPINDEX}
-        key: .1.3.6.1.4.1.37447.1.2.1.52.[{#SNMPINDEX}]
-        delay: 1m
-        history: 2w
-        trends: '0'
-        units: B
-        description: Total number of bytes used on disk for volumes - low order bytes.
-        tags:
-        - tag: Application
-          value: Nimble OS
-      - uuid: 6c1a0136562742519c086630e0d281f3
-        name: Nimble-OS::volDiskVolBytesUsedHigh[{#SNMPINDEX}]
-        type: SNMP_AGENT
-        snmp_oid: .1.3.6.1.4.1.37447.1.2.1.53.{#SNMPINDEX}
-        key: .1.3.6.1.4.1.37447.1.2.1.53.[{#SNMPINDEX}]
-        delay: 1m
-        history: 2w
-        value_type: FLOAT
-        trends: '0'
-        units: B
-        description: Total number of bytes used on disk for volumes - high order bytes.
-        tags:
-        - tag: Application
-          value: Nimble OS
-      - uuid: 766124d2feba490ab901c08d098fb8de
-        name: Nimble-OS::volDiskSnapBytesUsedLow[{#SNMPINDEX}]
-        type: SNMP_AGENT
-        snmp_oid: .1.3.6.1.4.1.37447.1.2.1.54.{#SNMPINDEX}
-        key: .1.3.6.1.4.1.37447.1.2.1.54.[{#SNMPINDEX}]
-        delay: 1m
-        history: 2w
-        value_type: FLOAT
-        trends: '0'
-        units: B
-        description: Total number of bytes used on disk for snapshots - low order
-          bytes.
-        tags:
-        - tag: Application
-          value: Nimble OS
-      - uuid: 67f1ca591cfc486a8a7b0ab7a2c1255d
-        name: Nimble-OS::volDiskSnapBytesUsedHigh[{#SNMPINDEX}]
-        type: SNMP_AGENT
-        snmp_oid: .1.3.6.1.4.1.37447.1.2.1.55.{#SNMPINDEX}
-        key: .1.3.6.1.4.1.37447.1.2.1.55.[{#SNMPINDEX}]
-        delay: 1m
-        history: 2w
-        value_type: FLOAT
-        trends: '0'
-        units: B
-        description: Total number of bytes used on disk for snapshots - high order
-          bytes.
-        tags:
-        - tag: Application
-          value: Nimble OS
-    tags:
-    - tag: class
-      value: storage
-    - tag: target
-      value: Nimble OS
-    macros:
-    - macro: '{$SNMP_PORT}'
-      value: '161'
-    valuemaps:
-    - uuid: 48874c746d7e48dea5941b4c5d62aad7
-      name: Nimble-OS::volOnline
-      mappings:
-      - value: '1'
-        newvalue: 'true'
-      - value: '2'
-        newvalue: 'false'
+        - tag: class
+          value: storage
+        - tag: target
+          value: 'Nimble OS'
+      macros:
+        - macro: '{$SNMP_PORT}'
+          value: '161'
+      valuemaps:
+        - uuid: 48874c746d7e48dea5941b4c5d62aad7
+          name: 'Nimble-OS::volOnline'
+          mappings:
+            - value: '1'
+              newvalue: 'true'
+            - value: '2'
+              newvalue: 'false'


### PR DESCRIPTION
This PR introduces a new Zabbix template—Nimble OS by SNMP—to provide low-level discovery capabilities as well as capacity monitoring for any Nimble OS–based SAN array. Key features include:

Core SNMP items:

- System timestamp

-  I/O counters: total reads/writes, sequential reads/writes

- I/O latency (read/write time in ms, converted from μs)

- I/O volume counters (bytes)

- Cache hit statistics

Low-level discovery rule (volTable) for all volumes, with item prototypes per volume:

- Volume ID, name, size (low/high bytes), usage (low/high bytes), reserve (low/high bytes)

- Online status (with value map true/false)

- Number of connections, per-volume timestamps, per-volume I/O and latency breakdowns